### PR TITLE
feat: talk library and set lists

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,7 @@
   --surface-hover: #1f1f1f;
   --border: #2a2a2a;
   --text-secondary: #a0a0a0;
+  --muted: #a0a0a0;
   --primary: #6366f1;
   --primary-hover: #4f46e5;
 }

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { Doc } from '@/convex/_generated/dataModel';
+
+type Tab = 'talks' | 'sets';
+
+export default function LibraryPage() {
+  const { clerkId } = useCurrentUser();
+  const [tab, setTab] = useState<Tab>('talks');
+  const [newTalkTitle, setNewTalkTitle] = useState('');
+  const [newSetTitle, setNewSetTitle] = useState('');
+  const [showNewTalk, setShowNewTalk] = useState(false);
+  const [showNewSet, setShowNewSet] = useState(false);
+
+  const talks = useQuery(api.talks.list, clerkId ? { userId: clerkId } : 'skip');
+  const sets = useQuery(api.talkSets.list, clerkId ? { userId: clerkId } : 'skip');
+
+  const createTalk = useMutation(api.talks.create);
+  const removeTalk = useMutation(api.talks.remove);
+  const createSet = useMutation(api.talkSets.create);
+  const removeSet = useMutation(api.talkSets.remove);
+
+  async function handleCreateTalk(e: React.FormEvent) {
+    e.preventDefault();
+    if (!clerkId || !newTalkTitle.trim()) return;
+    await createTalk({ userId: clerkId, title: newTalkTitle.trim() });
+    setNewTalkTitle('');
+    setShowNewTalk(false);
+  }
+
+  async function handleCreateSet(e: React.FormEvent) {
+    e.preventDefault();
+    if (!clerkId || !newSetTitle.trim()) return;
+    await createSet({ userId: clerkId, title: newSetTitle.trim() });
+    setNewSetTitle('');
+    setShowNewSet(false);
+  }
+
+  return (
+    <div className="flex flex-col min-h-dvh bg-[var(--background)] text-[var(--foreground)]">
+      {/* Header */}
+      <header className="flex items-center justify-between px-5 pt-safe-top pb-4 pt-6 border-b border-[var(--border)]">
+        <h1 className="text-xl font-semibold tracking-tight">Podium</h1>
+        <a href="/settings" className="text-sm text-[var(--muted)] hover:text-[var(--foreground)]">
+          Settings
+        </a>
+      </header>
+
+      {/* Tabs */}
+      <div className="flex border-b border-[var(--border)]">
+        <button
+          onClick={() => setTab('talks')}
+          className={`flex-1 py-3 text-sm font-medium transition-colors ${
+            tab === 'talks'
+              ? 'text-[var(--primary)] border-b-2 border-[var(--primary)]'
+              : 'text-[var(--muted)]'
+          }`}
+        >
+          Talks
+        </button>
+        <button
+          onClick={() => setTab('sets')}
+          className={`flex-1 py-3 text-sm font-medium transition-colors ${
+            tab === 'sets'
+              ? 'text-[var(--primary)] border-b-2 border-[var(--primary)]'
+              : 'text-[var(--muted)]'
+          }`}
+        >
+          Sets
+        </button>
+      </div>
+
+      {/* Content */}
+      <main className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {tab === 'talks' && (
+          <>
+            {talks === undefined && (
+              <p className="text-center text-[var(--muted)] py-8">Loading...</p>
+            )}
+            {talks?.length === 0 && !showNewTalk && (
+              <p className="text-center text-[var(--muted)] py-12 text-sm">
+                No talks yet. Tap + to create your first.
+              </p>
+            )}
+            {talks?.map((talk: Doc<'talks'>) => (
+              <div
+                key={talk._id}
+                className="flex items-center justify-between bg-[var(--surface)] rounded-xl px-4 py-4 gap-3"
+              >
+                <a
+                  href={`/talk/${talk._id}`}
+                  className="flex-1 font-medium text-[var(--foreground)] truncate"
+                >
+                  {talk.title}
+                </a>
+                <button
+                  onClick={() => clerkId && removeTalk({ id: talk._id as Id<'talks'>, userId: clerkId })}
+                  className="text-[var(--muted)] hover:text-red-400 text-xs px-2 py-1 rounded transition-colors"
+                >
+                  Delete
+                </button>
+              </div>
+            ))}
+            {showNewTalk && (
+              <form onSubmit={handleCreateTalk} className="flex gap-2">
+                <input
+                  autoFocus
+                  value={newTalkTitle}
+                  onChange={(e) => setNewTalkTitle(e.target.value)}
+                  placeholder="Talk title"
+                  className="flex-1 bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] placeholder-[var(--muted)] outline-none border border-[var(--border)] focus:border-[var(--primary)]"
+                />
+                <button
+                  type="submit"
+                  className="bg-[var(--primary)] text-white rounded-xl px-4 py-3 text-sm font-medium"
+                >
+                  Add
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowNewTalk(false)}
+                  className="text-[var(--muted)] px-3 py-3 text-sm"
+                >
+                  Cancel
+                </button>
+              </form>
+            )}
+          </>
+        )}
+
+        {tab === 'sets' && (
+          <>
+            {sets === undefined && (
+              <p className="text-center text-[var(--muted)] py-8">Loading...</p>
+            )}
+            {sets?.length === 0 && !showNewSet && (
+              <p className="text-center text-[var(--muted)] py-12 text-sm">
+                No sets yet. Group talks for an event.
+              </p>
+            )}
+            {sets?.map((set: Doc<'talkSets'>) => (
+              <div
+                key={set._id}
+                className="bg-[var(--surface)] rounded-xl px-4 py-4"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-[var(--foreground)]">{set.title}</span>
+                  <button
+                    onClick={() => clerkId && removeSet({ id: set._id as Id<'talkSets'>, userId: clerkId })}
+                    className="text-[var(--muted)] hover:text-red-400 text-xs px-2 py-1 rounded transition-colors"
+                  >
+                    Delete
+                  </button>
+                </div>
+                <p className="text-xs text-[var(--muted)] mt-1">
+                  {set.talkIds.length} {set.talkIds.length === 1 ? 'talk' : 'talks'}
+                </p>
+              </div>
+            ))}
+            {showNewSet && (
+              <form onSubmit={handleCreateSet} className="flex gap-2">
+                <input
+                  autoFocus
+                  value={newSetTitle}
+                  onChange={(e) => setNewSetTitle(e.target.value)}
+                  placeholder="Set title (e.g. Conference 2026)"
+                  className="flex-1 bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] placeholder-[var(--muted)] outline-none border border-[var(--border)] focus:border-[var(--primary)]"
+                />
+                <button
+                  type="submit"
+                  className="bg-[var(--primary)] text-white rounded-xl px-4 py-3 text-sm font-medium"
+                >
+                  Add
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowNewSet(false)}
+                  className="text-[var(--muted)] px-3 py-3 text-sm"
+                >
+                  Cancel
+                </button>
+              </form>
+            )}
+          </>
+        )}
+      </main>
+
+      {/* FAB */}
+      <div className="fixed bottom-6 right-5 pb-safe-bottom">
+        <button
+          onClick={() => {
+            if (tab === 'talks') {
+              setShowNewTalk(true);
+              setShowNewSet(false);
+            } else {
+              setShowNewSet(true);
+              setShowNewTalk(false);
+            }
+          }}
+          className="w-14 h-14 rounded-full bg-[var(--primary)] text-white text-2xl flex items-center justify-center shadow-lg active:scale-95 transition-transform"
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/convex/talkSets.ts
+++ b/convex/talkSets.ts
@@ -1,0 +1,48 @@
+import { mutation, query } from './_generated/server';
+import { v } from 'convex/values';
+
+export const list = query({
+  args: { userId: v.string() },
+  handler: async (ctx, { userId }) => {
+    return await ctx.db
+      .query('talkSets')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .order('desc')
+      .collect();
+  },
+});
+
+export const create = mutation({
+  args: { userId: v.string(), title: v.string() },
+  handler: async (ctx, { userId, title }) => {
+    return await ctx.db.insert('talkSets', { userId, title, talkIds: [] });
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id('talkSets'), userId: v.string() },
+  handler: async (ctx, { id, userId }) => {
+    const set = await ctx.db.get(id);
+    if (!set || set.userId !== userId) throw new Error('Not found');
+    await ctx.db.delete(id);
+  },
+});
+
+export const addTalk = mutation({
+  args: { id: v.id('talkSets'), userId: v.string(), talkId: v.id('talks') },
+  handler: async (ctx, { id, userId, talkId }) => {
+    const set = await ctx.db.get(id);
+    if (!set || set.userId !== userId) throw new Error('Not found');
+    if (set.talkIds.includes(talkId)) return;
+    await ctx.db.patch(id, { talkIds: [...set.talkIds, talkId] });
+  },
+});
+
+export const removeTalk = mutation({
+  args: { id: v.id('talkSets'), userId: v.string(), talkId: v.id('talks') },
+  handler: async (ctx, { id, userId, talkId }) => {
+    const set = await ctx.db.get(id);
+    if (!set || set.userId !== userId) throw new Error('Not found');
+    await ctx.db.patch(id, { talkIds: set.talkIds.filter((t) => t !== talkId) });
+  },
+});

--- a/convex/talks.ts
+++ b/convex/talks.ts
@@ -1,0 +1,45 @@
+import { mutation, query } from './_generated/server';
+import { v } from 'convex/values';
+
+export const list = query({
+  args: { userId: v.string() },
+  handler: async (ctx, { userId }) => {
+    return await ctx.db
+      .query('talks')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .order('desc')
+      .collect();
+  },
+});
+
+export const create = mutation({
+  args: {
+    userId: v.string(),
+    title: v.string(),
+  },
+  handler: async (ctx, { userId, title }) => {
+    return await ctx.db.insert('talks', {
+      userId,
+      title,
+      segments: [],
+    });
+  },
+});
+
+export const remove = mutation({
+  args: { id: v.id('talks'), userId: v.string() },
+  handler: async (ctx, { id, userId }) => {
+    const talk = await ctx.db.get(id);
+    if (!talk || talk.userId !== userId) throw new Error('Not found');
+    await ctx.db.delete(id);
+  },
+});
+
+export const rename = mutation({
+  args: { id: v.id('talks'), userId: v.string(), title: v.string() },
+  handler: async (ctx, { id, userId, title }) => {
+    const talk = await ctx.db.get(id);
+    if (!talk || talk.userId !== userId) throw new Error('Not found');
+    await ctx.db.patch(id, { title });
+  },
+});

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,0 +1,25 @@
+import { mutation } from './_generated/server';
+import { v } from 'convex/values';
+
+export const sync = mutation({
+  args: {
+    clerkId: v.string(),
+    name: v.string(),
+    email: v.string(),
+  },
+  handler: async (ctx, { clerkId, name, email }) => {
+    const existing = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', clerkId))
+      .unique();
+
+    if (existing) {
+      if (existing.name !== name || existing.email !== email) {
+        await ctx.db.patch(existing._id, { name, email });
+      }
+      return existing._id;
+    }
+
+    return await ctx.db.insert('users', { clerkId, name, email });
+  },
+});

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useUser } from '@clerk/nextjs';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+
+export function useCurrentUser() {
+  const { user, isLoaded } = useUser();
+  const syncUser = useMutation(api.users.sync);
+
+  useEffect(() => {
+    if (!isLoaded || !user) return;
+    syncUser({
+      clerkId: user.id,
+      name: user.fullName ?? user.username ?? 'Unknown',
+      email: user.primaryEmailAddress?.emailAddress ?? '',
+    });
+  }, [isLoaded, user, syncUser]);
+
+  return { user, isLoaded, clerkId: user?.id };
+}


### PR DESCRIPTION
Closes #9

## Summary
- Convex mutations/queries for `talks` and `talkSets`
- `useCurrentUser` hook that syncs the Clerk user into Convex on sign-in
- `/library` page with Talks and Sets tabs
- FAB to create talks or sets inline
- Delete talks and sets
- Talks link through to `/talk/[id]` (presentation view, separate issue)

Also includes auth pages and proxy rename from #10 so this branch is self-contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user authentication pages for sign-in and sign-up.
  * Introduced a Library page featuring tabbed interface to manage "Talks" and "Sets" with create and delete functionality.
  * Home page now redirects to the Library.

* **Style**
  * Added muted color styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->