### PR TITLE
feat: talk presentation view and BYOK ElevenLabs key

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+
+export default function SettingsPage() {
+  const { clerkId } = useCurrentUser();
+  const settings = useQuery(api.users.getSettings, clerkId ? { clerkId } : 'skip');
+  const saveApiKey = useMutation(api.users.saveApiKey);
+  const clearApiKey = useMutation(api.users.clearApiKey);
+
+  const [keyInput, setKeyInput] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (settings?.elevenLabsApiKey) {
+      setKeyInput(settings.elevenLabsApiKey);
+    }
+  }, [settings]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!clerkId || !keyInput.trim()) return;
+    await saveApiKey({ clerkId, elevenLabsApiKey: keyInput.trim() });
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }
+
+  async function handleClear() {
+    if (!clerkId) return;
+    await clearApiKey({ clerkId });
+    setKeyInput('');
+  }
+
+  return (
+    <div className="flex flex-col min-h-dvh bg-[var(--background)] text-[var(--foreground)]">
+      <header className="flex items-center gap-3 px-5 pt-6 pb-4 border-b border-[var(--border)]">
+        <a href="/library" className="text-[var(--muted)] hover:text-[var(--foreground)] text-sm">
+          ← Library
+        </a>
+        <h1 className="text-lg font-semibold">Settings</h1>
+      </header>
+
+      <main className="flex-1 px-5 py-6 space-y-8 max-w-lg">
+        <section>
+          <h2 className="text-sm font-semibold text-[var(--muted)] uppercase tracking-wider mb-3">
+            ElevenLabs
+          </h2>
+          <p className="text-sm text-[var(--muted)] mb-4">
+            Enter your ElevenLabs API key to enable text-to-speech. Your key is stored securely and never shared.
+          </p>
+          <form onSubmit={handleSave} className="space-y-3">
+            <input
+              type="password"
+              value={keyInput}
+              onChange={(e) => setKeyInput(e.target.value)}
+              placeholder="sk_..."
+              className="w-full bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] placeholder-[var(--muted)] outline-none border border-[var(--border)] focus:border-[var(--primary)] font-mono"
+            />
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                disabled={!keyInput.trim()}
+                className="flex-1 bg-[var(--primary)] text-white rounded-xl py-3 text-sm font-medium disabled:opacity-40 transition-opacity"
+              >
+                {saved ? 'Saved!' : 'Save key'}
+              </button>
+              {settings?.elevenLabsApiKey && (
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  className="px-4 py-3 text-sm text-red-400 hover:text-red-300 transition-colors"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+          </form>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/app/talk/[id]/page.tsx
+++ b/app/talk/[id]/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { use } from 'react';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useTTS } from '@/hooks/useTTS';
+
+export default function TalkPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { clerkId } = useCurrentUser();
+
+  const talk = useQuery(api.talks.get, { id: id as Id<'talks'> });
+  const settings = useQuery(api.users.getSettings, clerkId ? { clerkId } : 'skip');
+
+  const apiKey = settings?.elevenLabsApiKey;
+  const { speak, state, activeId } = useTTS(apiKey);
+
+  if (talk === undefined) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-[var(--background)]">
+        <p className="text-[var(--muted)] text-sm">Loading...</p>
+      </div>
+    );
+  }
+
+  if (talk === null) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-[var(--background)]">
+        <p className="text-[var(--muted)] text-sm">Talk not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col min-h-dvh bg-[var(--background)] text-[var(--foreground)]">
+      {/* Header */}
+      <header className="flex items-center justify-between px-5 pt-6 pb-4 border-b border-[var(--border)]">
+        <a href="/library" className="text-[var(--muted)] hover:text-[var(--foreground)] text-sm">
+          ← Library
+        </a>
+        <h1 className="text-base font-semibold truncate mx-4 flex-1 text-center">{talk.title}</h1>
+        <div className="w-12" />
+      </header>
+
+      {/* No API key banner */}
+      {!apiKey && (
+        <div className="mx-4 mt-4 px-4 py-3 bg-[var(--surface)] rounded-xl border border-[var(--border)] flex items-center justify-between gap-3">
+          <p className="text-sm text-[var(--muted)]">Add your ElevenLabs key to enable speech.</p>
+          <a href="/settings" className="text-sm text-[var(--primary)] font-medium whitespace-nowrap">
+            Settings →
+          </a>
+        </div>
+      )}
+
+      {/* Segments */}
+      <main className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {talk.segments.length === 0 && (
+          <p className="text-center text-[var(--muted)] py-12 text-sm">
+            This talk has no segments yet.
+          </p>
+        )}
+
+        {talk.segments.map((segment) => {
+          const isActive = activeId === segment.id;
+          const isLoading = isActive && state === 'loading';
+          const isPlaying = isActive && state === 'playing';
+
+          return (
+            <button
+              key={segment.id}
+              onClick={() => speak(segment.text, segment.id)}
+              disabled={!apiKey}
+              className={`w-full text-left px-5 py-5 rounded-2xl border transition-all active:scale-[0.98] ${
+                isPlaying
+                  ? 'bg-[var(--primary)] border-[var(--primary)] text-white'
+                  : isLoading
+                  ? 'bg-[var(--surface)] border-[var(--primary)] text-[var(--foreground)]'
+                  : 'bg-[var(--surface)] border-[var(--border)] text-[var(--foreground)] hover:border-[var(--primary)]'
+              } disabled:opacity-50 disabled:cursor-default`}
+            >
+              <p className="text-base leading-relaxed">{segment.text}</p>
+              {isLoading && (
+                <p className="text-xs mt-2 opacity-60">Speaking...</p>
+              )}
+            </button>
+          );
+        })}
+      </main>
+    </div>
+  );
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,6 +6,7 @@ export default defineSchema({
     clerkId: v.string(),
     name: v.string(),
     email: v.string(),
+    elevenLabsApiKey: v.optional(v.string()),
   }).index('by_clerk_id', ['clerkId']),
 
   talks: defineTable({

--- a/convex/talks.ts
+++ b/convex/talks.ts
@@ -1,6 +1,13 @@
 import { mutation, query } from './_generated/server';
 import { v } from 'convex/values';
 
+export const get = query({
+  args: { id: v.id('talks') },
+  handler: async (ctx, { id }) => {
+    return await ctx.db.get(id);
+  },
+});
+
 export const list = query({
   args: { userId: v.string() },
   handler: async (ctx, { userId }) => {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,4 +1,4 @@
-import { mutation } from './_generated/server';
+import { mutation, query } from './_generated/server';
 import { v } from 'convex/values';
 
 export const sync = mutation({
@@ -21,5 +21,39 @@ export const sync = mutation({
     }
 
     return await ctx.db.insert('users', { clerkId, name, email });
+  },
+});
+
+export const getSettings = query({
+  args: { clerkId: v.string() },
+  handler: async (ctx, { clerkId }) => {
+    return await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', clerkId))
+      .unique();
+  },
+});
+
+export const saveApiKey = mutation({
+  args: { clerkId: v.string(), elevenLabsApiKey: v.string() },
+  handler: async (ctx, { clerkId, elevenLabsApiKey }) => {
+    const user = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', clerkId))
+      .unique();
+    if (!user) throw new Error('User not found');
+    await ctx.db.patch(user._id, { elevenLabsApiKey });
+  },
+});
+
+export const clearApiKey = mutation({
+  args: { clerkId: v.string() },
+  handler: async (ctx, { clerkId }) => {
+    const user = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', clerkId))
+      .unique();
+    if (!user) throw new Error('User not found');
+    await ctx.db.patch(user._id, { elevenLabsApiKey: undefined });
   },
 });

--- a/hooks/useTTS.ts
+++ b/hooks/useTTS.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState, useRef } from 'react';
+
+export type TTSState = 'idle' | 'loading' | 'playing';
+
+export function useTTS(apiKey: string | undefined) {
+  const [state, setState] = useState<TTSState>('idle');
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  async function speak(text: string, id: string) {
+    if (!apiKey) return;
+
+    // Stop current audio
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+
+    // If tapping the same segment while playing, stop it
+    if (activeId === id && state === 'playing') {
+      setState('idle');
+      setActiveId(null);
+      return;
+    }
+
+    setState('loading');
+    setActiveId(id);
+
+    try {
+      const response = await fetch('https://api.elevenlabs.io/v1/text-to-speech/21m00Tcm4TlvDq8ikWAM', {
+        method: 'POST',
+        headers: {
+          'xi-api-key': apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text,
+          model_id: 'eleven_flash_v2_5',
+          voice_settings: { stability: 0.5, similarity_boost: 0.75 },
+        }),
+      });
+
+      if (!response.ok) throw new Error('TTS failed');
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audioRef.current = audio;
+
+      audio.onended = () => {
+        setState('idle');
+        setActiveId(null);
+        URL.revokeObjectURL(url);
+      };
+
+      audio.onerror = () => {
+        setState('idle');
+        setActiveId(null);
+      };
+
+      setState('playing');
+      await audio.play();
+    } catch {
+      setState('idle');
+      setActiveId(null);
+    }
+  }
+
+  function stop() {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+    setState('idle');
+    setActiveId(null);
+  }
+
+  return { speak, stop, state, activeId };
+}


### PR DESCRIPTION
Closes #12

## Summary
- `/talk/[id]` — full presentation view, segments listed as tappable cards; tapping speaks via ElevenLabs, tapping again stops; active segment highlighted in primary colour
- `/settings` — enter/save/remove ElevenLabs API key (stored on Convex user record)
- `useTTS` hook — calls ElevenLabs directly from the client using the user's own key
- Banner on talk page prompts user to add their key if not set
- `convex/users.ts` — added `getSettings`, `saveApiKey`, `clearApiKey`
- `convex/talks.ts` — added `get` query for single talk
- `convex/schema.ts` — added `elevenLabsApiKey` field to users table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings page to save, view, and remove your ElevenLabs API key
  * Talk detail page with text-to-speech playback for individual segments
  * Toggle play/pause controls for each segment's audio
  * Visual feedback indicating playback state and confirmation messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->