### PR TITLE
feat: redesign talk view for speech delivery

### DIFF
--- a/app/talk/[id]/page.tsx
+++ b/app/talk/[id]/page.tsx
@@ -28,15 +28,36 @@ export default function TalkPage({ params }: { params: Promise<{ id: string }> }
   function handleTap() {
     if (isLocked) return;
     if (speakState === 'spoken') {
-      if (!isLast) doAdvance();
+      if (!isLast) doAdvanceAndSpeak();
       return;
     }
     // idle — speak
     doSpeak();
   }
 
-  async function doSpeak() {
-    if (!apiKey || !current) return;
+  function doSpeak() {
+    speakAt(index);
+  }
+
+  function doAdvance() {
+    audioRef.current?.pause();
+    audioRef.current = null;
+    setSpeakState('idle');
+    setIndex((i) => i + 1);
+  }
+
+  function doAdvanceAndSpeak() {
+    audioRef.current?.pause();
+    audioRef.current = null;
+    const nextIndex = index + 1;
+    setIndex(nextIndex);
+    // speak the next segment immediately
+    speakAt(nextIndex);
+  }
+
+  async function speakAt(i: number) {
+    const segment = segments[i];
+    if (!apiKey || !segment) return;
 
     setSpeakState('loading');
 
@@ -47,7 +68,7 @@ export default function TalkPage({ params }: { params: Promise<{ id: string }> }
           method: 'POST',
           headers: { 'xi-api-key': apiKey, 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            text: current.text,
+            text: segment.text,
             model_id: 'eleven_flash_v2_5',
             voice_settings: { stability: 0.5, similarity_boost: 0.75 },
           }),
@@ -72,13 +93,6 @@ export default function TalkPage({ params }: { params: Promise<{ id: string }> }
     } catch {
       setSpeakState('idle');
     }
-  }
-
-  function doAdvance() {
-    audioRef.current?.pause();
-    audioRef.current = null;
-    setSpeakState('idle');
-    setIndex((i) => i + 1);
   }
 
   function back() {


### PR DESCRIPTION
Closes #4

## Summary
- One segment displayed at a time — no scrolling list
- Tap the whole screen to speak the current segment
- While speaking (loading or playing): entire screen is locked, nav is hidden, back link is invisible — no accidental taps possible
- ← / → nav to move between segments, disabled during speech
- Progress bar and counter at the top
- "Done" link on the last segment returns to library
- "Set key" shortcut in header if ElevenLabs key is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive tap-to-speak interface with progress tracking and navigation controls for segment-by-segment playback

* **Refactor**
  * Streamlined text-to-speech flow for improved performance and responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->