### PR TITLE
fix: allow legacy version field in talkVersions schema

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,8 +8,46 @@
  * @module
  */
 
-import type { AnyApi, AnyComponents } from "convex/server";
+import type * as talkSets from "../talkSets.js";
+import type * as talks from "../talks.js";
+import type * as users from "../users.js";
 
-export declare const api: AnyApi;
-export declare const internal: AnyApi;
-export declare const components: AnyComponents;
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  talkSets: typeof talkSets;
+  talks: typeof talks;
+  users: typeof users;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -43,6 +43,7 @@ export default defineSchema({
 
   talkVersions: defineTable({
     talkId: v.id('talks'),
+    version: v.optional(v.number()),
     fullText: v.optional(v.string()),
     segmentMode: v.optional(v.union(v.literal('paragraphs'), v.literal('sentences'))),
     segments: v.array(


### PR DESCRIPTION
## Summary
- A pre-existing `talkVersions` document with a legacy `version` field was causing `convex dev` to fail schema validation on startup
- Added `version: v.optional(v.number())` to the `talkVersions` table definition to accommodate the existing data

## Test plan
- [ ] Run `npx convex dev` and confirm schema validation passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional version field to track different versions of talk content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->