### PR TITLE
feat: global voice selection in settings

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { fetchVoices, ElevenLabsVoice, DEFAULT_VOICE_ID } from '@/lib/tts';
 
 const MASKED = '••••••••••••••••';
 
@@ -12,11 +13,16 @@ export default function SettingsPage() {
   const settings = useQuery(api.users.getSettings, clerkId ? { clerkId } : 'skip');
   const saveApiKey = useMutation(api.users.saveApiKey);
   const clearApiKey = useMutation(api.users.clearApiKey);
+  const saveVoiceId = useMutation(api.users.saveVoiceId);
 
   const [keyInput, setKeyInput] = useState('');
-  // Whether the field is showing the masked placeholder for an already-saved key
   const [masked, setMasked] = useState(false);
   const [saved, setSaved] = useState(false);
+
+  const [voices, setVoices] = useState<ElevenLabsVoice[]>([]);
+  const [voicesLoading, setVoicesLoading] = useState(false);
+  const [voicesError, setVoicesError] = useState(false);
+  const [previewAudio, setPreviewAudio] = useState<HTMLAudioElement | null>(null);
 
   useEffect(() => {
     if (settings?.elevenLabsApiKey) {
@@ -26,6 +32,29 @@ export default function SettingsPage() {
       setMasked(false);
     }
   }, [settings?.elevenLabsApiKey]);
+
+  useEffect(() => {
+    if (!settings?.elevenLabsApiKey) return;
+    setVoicesLoading(true);
+    setVoicesError(false);
+    fetchVoices(settings.elevenLabsApiKey)
+      .then((v) => setVoices(v.sort((a, b) => a.name.localeCompare(b.name))))
+      .catch(() => setVoicesError(true))
+      .finally(() => setVoicesLoading(false));
+  }, [settings?.elevenLabsApiKey]);
+
+  function handlePreview(voice: ElevenLabsVoice) {
+    previewAudio?.pause();
+    const audio = new Audio(voice.preview_url);
+    setPreviewAudio(audio);
+    audio.onended = () => setPreviewAudio(null);
+    audio.play();
+  }
+
+  async function handleSelectVoice(voiceId: string) {
+    if (!clerkId) return;
+    await saveVoiceId({ clerkId, voiceId });
+  }
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -100,6 +129,45 @@ export default function SettingsPage() {
             </div>
           </form>
         </section>
+
+        {settings?.elevenLabsApiKey && (
+          <section>
+            <h2 className="text-sm font-semibold text-[var(--muted)] uppercase tracking-wider mb-3">
+              Voice
+            </h2>
+            {voicesLoading && (
+              <p className="text-sm text-[var(--muted)]">Loading voices…</p>
+            )}
+            {voicesError && (
+              <p className="text-sm text-red-400">Failed to load voices.</p>
+            )}
+            {!voicesLoading && !voicesError && voices.length > 0 && (
+              <div className="flex items-center gap-2">
+                <select
+                  value={settings.voiceId ?? DEFAULT_VOICE_ID}
+                  onChange={(e) => handleSelectVoice(e.target.value)}
+                  className="flex-1 bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] outline-none border border-[var(--border)] focus:border-[var(--primary)]"
+                >
+                  {voices.map((voice) => (
+                    <option key={voice.voice_id} value={voice.voice_id}>
+                      {voice.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => {
+                    const voice = voices.find((v) => v.voice_id === (settings.voiceId ?? DEFAULT_VOICE_ID));
+                    if (voice) handlePreview(voice);
+                  }}
+                  className="px-4 py-3 rounded-xl bg-[var(--surface)] border border-[var(--border)] text-sm text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+                >
+                  ▶
+                </button>
+              </div>
+            )}
+          </section>
+        )}
       </main>
     </div>
   );

--- a/app/talk/[id]/page.tsx
+++ b/app/talk/[id]/page.tsx
@@ -79,7 +79,7 @@ export default function TalkPage({ params }: { params: Promise<{ id: string }> }
             const ttsText = seg.elements
               ? buildTTSText(seg.elements as SegmentElement[])
               : seg.text;
-            const blob = await fetchTTSBlob(ttsText, apiKey!, signal);
+            const blob = await fetchTTSBlob(ttsText, apiKey!, settings?.voiceId, signal);
             if (signal.aborted) return;
             await setCachedAudio(key, blob);
             audioUrls.current.set(i, URL.createObjectURL(blob));

--- a/app/talk/[id]/segments/page.tsx
+++ b/app/talk/[id]/segments/page.tsx
@@ -124,11 +124,13 @@ function SegmentBrickEditor({
   segmentId,
   initialElements,
   apiKey,
+  voiceId,
   onSave,
 }: {
   segmentId: string;
   initialElements: SegmentElement[];
   apiKey: string | undefined;
+  voiceId: string | undefined;
   onSave: (segmentId: string, elements: SegmentElement[]) => Promise<void>;
 }) {
   const [elements, setElements] = useState<SegmentElement[]>(initialElements);
@@ -199,7 +201,7 @@ function SegmentBrickEditor({
     setTesting(true);
     try {
       const ttsText = buildTTSText(elements);
-      const blob = await fetchTTSBlob(ttsText, apiKey);
+      const blob = await fetchTTSBlob(ttsText, apiKey, voiceId);
       const url = URL.createObjectURL(blob);
       const audio = new Audio(url);
       audio.onended = () => { URL.revokeObjectURL(url); setTesting(false); };
@@ -321,6 +323,7 @@ export default function SegmentsPage({ params }: { params: Promise<{ id: string 
   const saveSegmentElements = useMutation(api.talks.saveSegmentElements);
 
   const apiKey = settings?.elevenLabsApiKey;
+  const voiceId = settings?.voiceId;
 
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
@@ -392,6 +395,7 @@ export default function SegmentsPage({ params }: { params: Promise<{ id: string 
                     segmentId={seg.id}
                     initialElements={initialElements}
                     apiKey={apiKey}
+                    voiceId={voiceId}
                     onSave={handleSave}
                   />
                 </div>

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,6 +7,7 @@ export default defineSchema({
     name: v.string(),
     email: v.string(),
     elevenLabsApiKey: v.optional(v.string()),
+    voiceId: v.optional(v.string()),
   }).index('by_clerk_id', ['clerkId']),
 
   talks: defineTable({

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -46,6 +46,18 @@ export const saveApiKey = mutation({
   },
 });
 
+export const saveVoiceId = mutation({
+  args: { clerkId: v.string(), voiceId: v.string() },
+  handler: async (ctx, { clerkId, voiceId }) => {
+    const user = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', clerkId))
+      .unique();
+    if (!user) throw new Error('User not found');
+    await ctx.db.patch(user._id, { voiceId });
+  },
+});
+
 export const clearApiKey = mutation({
   args: { clerkId: v.string() },
   handler: async (ctx, { clerkId }) => {

--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -1,13 +1,14 @@
-const VOICE_ID = 'bIHbv24MWmeRgasZH58o';
+export const DEFAULT_VOICE_ID = 'bIHbv24MWmeRgasZH58o'; // Will
 const MODEL_ID = 'eleven_v3';
 
 export async function fetchTTSBlob(
   text: string,
   apiKey: string,
+  voiceId: string = DEFAULT_VOICE_ID,
   signal?: AbortSignal
 ): Promise<Blob> {
   const res = await fetch(
-    `https://api.elevenlabs.io/v1/text-to-speech/${VOICE_ID}`,
+    `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
     {
       method: 'POST',
       headers: { 'xi-api-key': apiKey, 'Content-Type': 'application/json' },
@@ -21,4 +22,19 @@ export async function fetchTTSBlob(
   );
   if (!res.ok) throw new Error(`TTS failed: ${res.status}`);
   return res.blob();
+}
+
+export interface ElevenLabsVoice {
+  voice_id: string;
+  name: string;
+  preview_url: string;
+}
+
+export async function fetchVoices(apiKey: string): Promise<ElevenLabsVoice[]> {
+  const res = await fetch('https://api.elevenlabs.io/v1/voices', {
+    headers: { 'xi-api-key': apiKey },
+  });
+  if (!res.ok) throw new Error(`Failed to fetch voices: ${res.status}`);
+  const data = await res.json();
+  return data.voices as ElevenLabsVoice[];
 }


### PR DESCRIPTION
Closes #53

## Summary
- `voiceId` added to users schema and `saveVoiceId` mutation
- Settings page shows a dropdown of all ElevenLabs voices (loaded from API) with a preview button; selection saves immediately
- `fetchTTSBlob` accepts optional `voiceId`, falls back to Will
- Both the talk page and brick editor test button use the saved voice

## Test plan
- [ ] Open Settings with a saved API key — voice dropdown should load
- [ ] Preview a voice with ▶
- [ ] Select a voice — confirm it persists on reload
- [ ] Play a talk segment — audio should use the selected voice
- [ ] Test button in brick editor should use the selected voice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice selection functionality in settings with the ability to preview voices before choosing
  * Selected voice preference is automatically saved and applied across the application during text-to-speech generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->