### PR TITLE
feat: deep slate visual redesign

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,15 +1,15 @@
 @import "tailwindcss";
 
 :root {
-  --background: #0a0a0a;
-  --foreground: #ededed;
-  --surface: #141414;
-  --surface-hover: #1f1f1f;
-  --border: #2a2a2a;
-  --text-secondary: #a0a0a0;
-  --muted: #a0a0a0;
-  --primary: #6366f1;
-  --primary-hover: #4f46e5;
+  --background: #0f172a;
+  --foreground: #f8fafc;
+  --surface: #1e293b;
+  --surface-hover: #293548;
+  --border: #334155;
+  --text-secondary: #94a3b8;
+  --muted: #94a3b8;
+  --primary: #38bdf8;
+  --primary-hover: #0ea5e9;
 }
 
 @theme inline {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-title" content="Podium" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="theme-color" content="#0a0a0a" />
+        <meta name="theme-color" content="#0f172a" />
         <link rel="manifest" href="/manifest.json" />
       </head>
       <body className={`${inter.className} bg-background text-foreground antialiased`} suppressHydrationWarning>


### PR DESCRIPTION
Closes #59

Replace near-black/indigo palette with slate-900 base and sky-400 accent. Updates all 8 CSS tokens and theme-color meta tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the application's visual design with an updated color palette, including new background, surface, border, text, and primary accent colors for enhanced visual consistency.
  * Updated the browser theme color to match the redesigned color scheme, ensuring a cohesive experience across the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->