### PR TITLE
Expose manifest.json outside Clerk middleware

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -13,7 +13,7 @@ export default clerkMiddleware(async (auth, req) => {
 
 export const config = {
   matcher: [
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/((?!_next|manifest\\.json|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
   ],
 };


### PR DESCRIPTION
## Summary
- exclude /manifest.json from Clerk middleware matching
- keep the web app manifest publicly reachable for signed-out visitors
- restore Android PWA installability instead of shortcut-only behavior

## Root cause
The deployed site was returning 404 for /manifest.json with Clerk auth headers, so Chrome could not read the manifest and fell back to a browser shortcut.

## Testing
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved middleware configuration to properly exclude web app manifest files from authentication processing, ensuring correct handling of system-level configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->