### PR TITLE
Fix offline data sync for installed app

### DIFF
--- a/app/library/OfflineLibraryPage.tsx
+++ b/app/library/OfflineLibraryPage.tsx
@@ -1,16 +1,40 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { OfflineBanner } from '@/components/offline/OfflineBanner';
 import { OfflineStatusBadge } from '@/components/offline/OfflineStatusBadge';
 import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
 import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { listTalkData } from '@/lib/audioStore';
 
 type Tab = 'talks' | 'sets';
 
 export default function OfflineLibraryPage() {
-  const { library, lastSyncedAt } = useOfflineBoot();
+  const { library, lastSyncedAt, syncState } = useOfflineBoot();
   const [tab, setTab] = useState<Tab>('talks');
+  const [cachedTalkIds, setCachedTalkIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadCachedTalks() {
+      const talks = await listTalkData();
+      if (cancelled) return;
+      setCachedTalkIds(new Set(talks.map((talk) => talk._id)));
+    }
+
+    void loadCachedTalks();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const partialDetail = useMemo(() => (
+    syncState === 'partial'
+      ? 'Recovered cached talks from this device. Some set or readiness metadata may be incomplete.'
+      : undefined
+  ), [syncState]);
 
   if (!library) {
     return (
@@ -29,7 +53,7 @@ export default function OfflineLibraryPage() {
       </header>
 
       <div className="px-4 pt-4">
-        <OfflineBanner lastSyncedAt={lastSyncedAt} />
+        <OfflineBanner lastSyncedAt={lastSyncedAt} detail={partialDetail} />
       </div>
 
       <div className="mt-4 flex border-y border-[var(--border)]">
@@ -56,7 +80,7 @@ export default function OfflineLibraryPage() {
             )}
             {library.talks.map((talk) => {
               const status = library.talkStatusById[talk._id];
-              const canOpen = !!status?.hasDocument;
+              const canOpen = status?.hasDocument || cachedTalkIds.has(talk._id);
 
               return (
                 <div key={talk._id} className="flex items-center justify-between bg-[var(--surface)] rounded-xl px-4 py-4 gap-3">
@@ -69,7 +93,10 @@ export default function OfflineLibraryPage() {
                       <span className="block truncate font-medium text-[var(--muted)]">{talk.title}</span>
                     )}
                     <div className="mt-2">
-                      <OfflineStatusBadge status={status} />
+                      <OfflineStatusBadge
+                        status={status}
+                        documentAvailable={cachedTalkIds.has(talk._id)}
+                      />
                     </div>
                   </div>
                   {!canOpen && (

--- a/app/library/OnlineLibraryPage.tsx
+++ b/app/library/OnlineLibraryPage.tsx
@@ -4,14 +4,12 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Doc, Id } from '@/convex/_generated/dataModel';
+import { OfflineStatusBadge } from '@/components/offline/OfflineStatusBadge';
+import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { useOfflineLibrarySync } from '@/hooks/useOfflineLibrarySync';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import { parseFile, splitIntoSentences, joinFullText } from '@/lib/parseFile';
-import {
-  getTalkPreparedState,
-  saveLibrarySnapshot,
-  type CachedTalkStatus,
-} from '@/lib/offlineStore';
-import { OfflineStatusBadge } from '@/components/offline/OfflineStatusBadge';
+import { getTalkPreparedState, type CachedTalkStatus } from '@/lib/offlineStore';
 
 const PREVIEW_CAP = 100;
 
@@ -28,6 +26,7 @@ interface ImportDraft {
 
 export default function OnlineLibraryPage() {
   const { clerkId } = useOnlineCurrentUser();
+  const { refreshOfflineBootstrap } = useOfflineBoot();
   const [tab, setTab] = useState<Tab>('talks');
   const [createMode, setCreateMode] = useState<CreateMode>('none');
   const [newTalkTitle, setNewTalkTitle] = useState('');
@@ -39,6 +38,7 @@ export default function OnlineLibraryPage() {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [assignTalkId, setAssignTalkId] = useState<string | null>(null);
   const [talkStatuses, setTalkStatuses] = useState<Record<string, CachedTalkStatus>>({});
+  const [statusesReady, setStatusesReady] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const talks = useQuery(api.talks.list, clerkId ? { userId: clerkId } : 'skip');
@@ -60,45 +60,51 @@ export default function OnlineLibraryPage() {
   }, [importDraft]);
 
   useEffect(() => {
-    if (!clerkId || !talks || !sets) return;
+    if (!clerkId || !talks) {
+      setStatusesReady(false);
+      return;
+    }
 
     const userId = clerkId;
     const liveTalks = talks;
-    const liveSets = sets;
     let cancelled = false;
+    setStatusesReady(false);
 
-    async function persistSnapshot() {
-      const statusEntries = await Promise.all(
+    async function loadStatuses() {
+      const entries = await Promise.all(
         liveTalks.map(async (talk) => {
           const status = await getTalkPreparedState(userId, talk._id);
-          return [talk._id, status] as const;
+          return [talk._id, status ?? {
+            talkId: talk._id,
+            hasDocument: true,
+            hasAudio: false,
+            segmentCount: talk.segments.length,
+            cachedAudioSegments: 0,
+            lastPreparedAt: null,
+          }] as const;
         })
       );
 
       if (cancelled) return;
 
-      const talkStatusById: Record<string, CachedTalkStatus> = {};
-      statusEntries.forEach(([talkId, status]) => {
-        if (!status) return;
-        talkStatusById[talkId] = status;
-      });
-
-      setTalkStatuses(talkStatusById);
-
-      await saveLibrarySnapshot(
-        userId,
-        liveTalks.map((talk) => ({ _id: talk._id, title: talk.title })),
-        liveSets.map((set) => ({ _id: set._id, title: set.title, talkIds: set.talkIds })),
-        talkStatusById
-      );
+      setTalkStatuses(Object.fromEntries(entries));
+      setStatusesReady(true);
     }
 
-    void persistSnapshot();
+    void loadStatuses();
 
     return () => {
       cancelled = true;
     };
-  }, [clerkId, sets, talks]);
+  }, [clerkId, talks]);
+
+  const { syncState, syncError } = useOfflineLibrarySync({
+    userId: clerkId,
+    talks: statusesReady ? talks : undefined,
+    sets: statusesReady ? sets : undefined,
+    talkStatuses,
+    refreshOfflineBootstrap,
+  });
 
   function closeFab() { setFabOpen(false); }
 
@@ -172,10 +178,29 @@ export default function OnlineLibraryPage() {
     setCreateMode('none');
   }
 
+  const syncLabel = syncState === 'syncing'
+    ? 'Syncing offline data...'
+    : syncState === 'ready'
+      ? 'Available offline'
+      : syncState === 'error'
+        ? 'Offline sync failed'
+        : 'Preparing offline data...';
+
+  const syncClassName = syncState === 'ready'
+    ? 'text-emerald-400'
+    : syncState === 'error'
+      ? 'text-red-400'
+      : 'text-[var(--muted)]';
+
   return (
     <div className="flex flex-col min-h-dvh bg-[var(--background)] text-[var(--foreground)]">
       <header className="flex items-center justify-between px-5 pt-6 pb-4 border-b border-[var(--border)]">
-        <h1 className="text-2xl font-semibold tracking-tight" style={{ fontFamily: 'var(--font-display)' }}>Podium</h1>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight" style={{ fontFamily: 'var(--font-display)' }}>Podium</h1>
+          <p className={`mt-1 text-xs ${syncClassName}`} title={syncError ?? undefined}>
+            {syncLabel}
+          </p>
+        </div>
         <a href="/settings" className="text-sm text-[var(--muted)] hover:text-[var(--foreground)]">
           Settings
         </a>
@@ -211,7 +236,10 @@ export default function OnlineLibraryPage() {
                     {talk.title}
                   </a>
                   <div className="mt-2">
-                    <OfflineStatusBadge status={talkStatuses[talk._id]} />
+                    <OfflineStatusBadge
+                      status={talkStatuses[talk._id]}
+                      documentAvailable
+                    />
                   </div>
                 </div>
                 <div className="flex items-center gap-1 shrink-0">

--- a/app/talk/[id]/OfflineTalkPage.tsx
+++ b/app/talk/[id]/OfflineTalkPage.tsx
@@ -130,7 +130,7 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
     );
   }
 
-  if (talk === null || !status?.hasDocument) {
+  if (talk === null) {
     return (
       <OfflineUnavailable
         title="Talk unavailable offline"
@@ -156,7 +156,11 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
       {!audioReady && (
         <div className="mx-5 mb-4 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3">
           <p className="text-sm text-[var(--foreground)]">This talk was not fully prepared for offline playback.</p>
-          <p className="mt-1 text-sm text-[var(--muted)]">The script is available, but cached speech audio is incomplete.</p>
+          <p className="mt-1 text-sm text-[var(--muted)]">
+            {status?.hasAudio
+              ? 'The script is available, but cached speech audio is incomplete.'
+              : 'The script is available, but cached speech audio has not been prepared for offline use.'}
+          </p>
         </div>
       )}
 

--- a/app/talk/[id]/OnlineTalkPage.tsx
+++ b/app/talk/[id]/OnlineTalkPage.tsx
@@ -59,6 +59,7 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
       title: talk.title,
       segments: talk.segments,
       voiceKey,
+      updatedAt: Date.now(),
     });
 
     if (!userId) return;

--- a/app/talk/[id]/edit/page.tsx
+++ b/app/talk/[id]/edit/page.tsx
@@ -8,7 +8,7 @@ import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
 import { useOfflineBoot } from '@/hooks/useOfflineBoot';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import { splitIntoSentences, joinFullText } from '@/lib/parseFile';
-import { clearTalkAudio } from '@/lib/audioStore';
+import { clearTalkAudio, saveTalkData } from '@/lib/audioStore';
 import { saveTalkPreparedState } from '@/lib/offlineStore';
 
 type SegmentMode = 'paragraphs' | 'sentences';
@@ -72,6 +72,12 @@ function OnlineEditPage({ params }: { params: Promise<{ id: string }> }) {
         fullText: joinFullText(paragraphs),
         segments,
         segmentMode: mode,
+      });
+      await saveTalkData(id, {
+        _id: id,
+        title: talk?.title ?? 'Untitled',
+        segments,
+        updatedAt: Date.now(),
       });
       await clearTalkAudio(id);
       if (clerkId) {

--- a/app/talk/[id]/history/page.tsx
+++ b/app/talk/[id]/history/page.tsx
@@ -8,7 +8,7 @@ import { Id } from '@/convex/_generated/dataModel';
 import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
 import { useOfflineBoot } from '@/hooks/useOfflineBoot';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
-import { clearTalkAudio } from '@/lib/audioStore';
+import { clearTalkAudio, saveTalkData } from '@/lib/audioStore';
 import { saveTalkPreparedState } from '@/lib/offlineStore';
 
 type ViewMode = 'preview' | 'diff';
@@ -46,6 +46,15 @@ function OnlineHistoryPage({ params }: { params: Promise<{ id: string }> }) {
     setRestoring(versionId);
     try {
       await restoreVersion({ talkId: id as Id<'talks'>, versionId, userId: clerkId });
+      const restoredVersion = versions?.find((version) => version._id === versionId);
+      if (restoredVersion && talk) {
+        await saveTalkData(id, {
+          _id: id,
+          title: talk.title,
+          segments: restoredVersion.segments,
+          updatedAt: Date.now(),
+        });
+      }
       await clearTalkAudio(id);
       if (talk) {
         await saveTalkPreparedState(clerkId, id, {

--- a/app/talk/[id]/segments/page.tsx
+++ b/app/talk/[id]/segments/page.tsx
@@ -16,7 +16,7 @@ import {
   tokenise,
 } from '@/lib/ssml';
 import { fetchTTSBlob, TTSConfig } from '@/lib/tts';
-import { clearTalkAudio } from '@/lib/audioStore';
+import { clearTalkAudio, saveTalkData } from '@/lib/audioStore';
 import { saveTalkPreparedState } from '@/lib/offlineStore';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -419,6 +419,16 @@ function OnlineSegmentsPage({ params }: { params: Promise<{ id: string }> }) {
     async (segmentId: string, elements: SegmentElement[]) => {
       if (!clerkId) return;
       await saveSegmentElements({ id: id as Id<'talks'>, userId: clerkId, segmentId, elements });
+      if (talk) {
+        await saveTalkData(id, {
+          _id: id,
+          title: talk.title,
+          segments: talk.segments.map((segment) => (
+            segment.id === segmentId ? { ...segment, elements } : segment
+          )),
+          updatedAt: Date.now(),
+        });
+      }
       await clearTalkAudio(id);
       if (talk) {
         await saveTalkPreparedState(clerkId, id, {

--- a/components/offline/OfflineBanner.tsx
+++ b/components/offline/OfflineBanner.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-export function OfflineBanner({ lastSyncedAt }: { lastSyncedAt: number | null }) {
+interface OfflineBannerProps {
+  lastSyncedAt: number | null;
+  detail?: string;
+}
+
+export function OfflineBanner({ lastSyncedAt, detail }: OfflineBannerProps) {
   const syncedLabel = lastSyncedAt
     ? new Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(lastSyncedAt))
     : 'Unknown';
@@ -11,6 +16,11 @@ export function OfflineBanner({ lastSyncedAt }: { lastSyncedAt: number | null })
       <p className="mt-1 text-sm text-[var(--muted)]">
         Showing last synced content from this device.
       </p>
+      {detail && (
+        <p className="mt-1 text-sm text-[var(--muted)]">
+          {detail}
+        </p>
+      )}
       <p className="mt-1 text-xs text-[var(--muted)]">
         Last sync: {syncedLabel}
       </p>

--- a/components/offline/OfflineStatusBadge.tsx
+++ b/components/offline/OfflineStatusBadge.tsx
@@ -4,10 +4,11 @@ import type { CachedTalkStatus } from '@/lib/offlineStore';
 
 interface OfflineStatusBadgeProps {
   status?: CachedTalkStatus;
+  documentAvailable?: boolean;
 }
 
-export function OfflineStatusBadge({ status }: OfflineStatusBadgeProps) {
-  if (!status?.hasDocument) {
+export function OfflineStatusBadge({ status, documentAvailable = false }: OfflineStatusBadgeProps) {
+  if (!status?.hasDocument && !documentAvailable) {
     return (
       <span className="rounded-full border border-[var(--border)] px-2 py-1 text-xs text-[var(--muted)]">
         Not prepared
@@ -15,7 +16,7 @@ export function OfflineStatusBadge({ status }: OfflineStatusBadgeProps) {
     );
   }
 
-  if (!status.hasAudio) {
+  if (!status?.hasAudio) {
     return (
       <span className="rounded-full border border-[var(--border)] px-2 py-1 text-xs text-[var(--muted)]">
         Document only

--- a/hooks/useOfflineBoot.tsx
+++ b/hooks/useOfflineBoot.tsx
@@ -9,7 +9,12 @@ import {
   useRef,
   useState,
 } from 'react';
-import { getOfflineBootstrap, type OfflineBootstrapRecord } from '@/lib/offlineStore';
+import {
+  getOfflineBootstrap,
+  rebuildOfflineBootstrapFromCachedTalks,
+  refreshOfflineBootstrap,
+  type OfflineBootstrapRecord,
+} from '@/lib/offlineStore';
 
 const ONLINE_BOOT_TIMEOUT_MS = 2000;
 
@@ -25,7 +30,9 @@ interface OfflineBootContextValue {
   lastUserId: string | null;
   lastSyncedAt: number | null;
   library: OfflineBootstrapRecord | null;
+  syncState: 'ready' | 'partial' | null;
   markOnlineRuntimeReady: () => void;
+  refreshOfflineBootstrap: () => Promise<OfflineBootstrapRecord | null>;
 }
 
 const OfflineBootContext = createContext<OfflineBootContextValue | null>(null);
@@ -47,8 +54,26 @@ export function OfflineBootProvider({ children }: { children: React.ReactNode })
 
   const loadBootstrap = useCallback(async () => {
     const bootstrap = await getOfflineBootstrap();
-    setLibrary(bootstrap ?? null);
-    return bootstrap ?? null;
+    if (bootstrap) {
+      setLibrary(bootstrap);
+      return bootstrap;
+    }
+
+    const rebuilt = await rebuildOfflineBootstrapFromCachedTalks();
+    setLibrary(rebuilt ?? null);
+    return rebuilt ?? null;
+  }, []);
+
+  const refreshBootstrap = useCallback(async () => {
+    const bootstrap = await refreshOfflineBootstrap();
+    if (bootstrap) {
+      setLibrary(bootstrap);
+      return bootstrap;
+    }
+
+    const rebuilt = await rebuildOfflineBootstrapFromCachedTalks();
+    setLibrary(rebuilt ?? null);
+    return rebuilt ?? null;
   }, []);
 
   const resolveMode = useCallback(async (nextOnline: boolean) => {
@@ -106,8 +131,8 @@ export function OfflineBootProvider({ children }: { children: React.ReactNode })
     onlineReadyRef.current = true;
     clearBootTimeout();
     setMode('online');
-    void loadBootstrap();
-  }, [clearBootTimeout, loadBootstrap]);
+    void refreshBootstrap();
+  }, [clearBootTimeout, refreshBootstrap]);
 
   const value = useMemo<OfflineBootContextValue>(() => ({
     mode,
@@ -115,8 +140,10 @@ export function OfflineBootProvider({ children }: { children: React.ReactNode })
     lastUserId: library?.userId ?? null,
     lastSyncedAt: library?.lastSyncedAt ?? null,
     library,
+    syncState: library?.syncState ?? null,
     markOnlineRuntimeReady,
-  }), [isOnline, library, markOnlineRuntimeReady, mode]);
+    refreshOfflineBootstrap: refreshBootstrap,
+  }), [isOnline, library, markOnlineRuntimeReady, mode, refreshBootstrap]);
 
   return (
     <OfflineBootContext.Provider value={value}>

--- a/hooks/useOfflineLibrarySync.ts
+++ b/hooks/useOfflineLibrarySync.ts
@@ -1,0 +1,140 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Doc } from '@/convex/_generated/dataModel';
+import { saveTalkDocuments, type CachedTalk } from '@/lib/audioStore';
+import {
+  pruneOfflineLibraryData,
+  saveOfflineLibraryBundle,
+  type CachedTalkStatus,
+  type OfflineBootstrapRecord,
+} from '@/lib/offlineStore';
+
+type LibrarySyncState = 'idle' | 'syncing' | 'ready' | 'error';
+
+interface UseOfflineLibrarySyncArgs {
+  userId?: string;
+  talks?: Doc<'talks'>[];
+  sets?: Doc<'talkSets'>[];
+  talkStatuses: Record<string, CachedTalkStatus>;
+  refreshOfflineBootstrap: () => Promise<OfflineBootstrapRecord | null>;
+}
+
+interface UseOfflineLibrarySyncResult {
+  syncState: LibrarySyncState;
+  syncError: string | null;
+  lastSyncedAt: number | null;
+}
+
+function toCachedTalk(talk: Doc<'talks'>): CachedTalk {
+  return {
+    _id: talk._id,
+    title: talk.title,
+    segments: talk.segments,
+    updatedAt: Date.now(),
+  };
+}
+
+export function useOfflineLibrarySync({
+  userId,
+  talks,
+  sets,
+  talkStatuses,
+  refreshOfflineBootstrap,
+}: UseOfflineLibrarySyncArgs): UseOfflineLibrarySyncResult {
+  const [syncState, setSyncState] = useState<LibrarySyncState>('idle');
+  const [syncError, setSyncError] = useState<string | null>(null);
+  const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
+
+  const payload = useMemo(() => {
+    if (!userId || !talks || !sets) return null;
+
+    return {
+      userId,
+      talks,
+      sets,
+      talkStatuses,
+    };
+  }, [sets, talkStatuses, talks, userId]);
+
+  const latestPayloadRef = useRef<typeof payload>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef(false);
+  const rerunRef = useRef(false);
+  const disposedRef = useRef(false);
+
+  useEffect(() => {
+    disposedRef.current = false;
+    return () => {
+      disposedRef.current = true;
+    };
+  }, []);
+
+  const runSync = useCallback(async () => {
+    const current = latestPayloadRef.current;
+    if (!current) return;
+
+    inFlightRef.current = true;
+    rerunRef.current = false;
+    setSyncState('syncing');
+    setSyncError(null);
+
+    try {
+      await saveTalkDocuments(current.talks.map(toCachedTalk));
+      await pruneOfflineLibraryData(current.userId, current.talks.map((talk) => talk._id));
+
+      const record = await saveOfflineLibraryBundle({
+        userId: current.userId,
+        talks: current.talks.map((talk) => ({ _id: talk._id, title: talk.title })),
+        sets: current.sets.map((set) => ({ _id: set._id, title: set.title, talkIds: set.talkIds })),
+        talkStatusById: current.talkStatuses,
+      });
+
+      const refreshed = await refreshOfflineBootstrap();
+      if (disposedRef.current) return;
+
+      setLastSyncedAt(refreshed?.lastSyncedAt ?? record.lastSyncedAt);
+      setSyncState('ready');
+    } catch (error) {
+      if (disposedRef.current) return;
+      setSyncState('error');
+      setSyncError(error instanceof Error ? error.message : 'Offline sync failed');
+    } finally {
+      inFlightRef.current = false;
+
+      if (rerunRef.current && !disposedRef.current) {
+        rerunRef.current = false;
+        void runSync();
+      }
+    }
+  }, [refreshOfflineBootstrap]);
+
+  useEffect(() => {
+    latestPayloadRef.current = payload;
+    if (!payload) {
+      setSyncState('idle');
+      return;
+    }
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      if (inFlightRef.current) {
+        rerunRef.current = true;
+        return;
+      }
+
+      void runSync();
+    }, 250);
+
+    return () => {
+      if (!timeoutRef.current) return;
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    };
+  }, [payload, runSync]);
+
+  return { syncState, syncError, lastSyncedAt };
+}

--- a/lib/audioStore.ts
+++ b/lib/audioStore.ts
@@ -21,12 +21,32 @@ export interface CachedTalk {
   title: string;
   segments: Array<{ id: string; text: string; elements?: unknown[] }>;
   voiceKey?: string;
+  updatedAt: number;
 }
 
 export async function saveTalkData(id: string, talk: CachedTalk): Promise<void> {
-  return set(id, talk, talkStore);
+  const existing = await get<CachedTalk>(id, talkStore);
+  return set(id, {
+    ...existing,
+    ...talk,
+    voiceKey: talk.voiceKey ?? existing?.voiceKey,
+  }, talkStore);
 }
 
 export async function getTalkData(id: string): Promise<CachedTalk | undefined> {
   return get<CachedTalk>(id, talkStore);
+}
+
+export async function saveTalkDocuments(talks: CachedTalk[]): Promise<void> {
+  await Promise.all(talks.map((talk) => saveTalkData(talk._id, talk)));
+}
+
+export async function listTalkData(): Promise<CachedTalk[]> {
+  const talkKeys = await keys<string>(talkStore);
+  const talks = await Promise.all(talkKeys.map((key) => get<CachedTalk>(key, talkStore)));
+  return talks.filter((talk): talk is CachedTalk => !!talk);
+}
+
+export async function deleteTalkData(id: string): Promise<void> {
+  await del(id, talkStore);
 }

--- a/lib/offlineStore.ts
+++ b/lib/offlineStore.ts
@@ -1,7 +1,7 @@
-import { createStore, get, set } from 'idb-keyval';
-import type { Doc } from '@/convex/_generated/dataModel';
+import { createStore, del, get, keys, set } from 'idb-keyval';
+import { deleteTalkData, listTalkData } from '@/lib/audioStore';
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 const bootstrapStore = createStore('podium-offline-bootstrap', 'records');
 const statusStore = createStore('podium-offline-status', 'talk-status');
@@ -16,13 +16,25 @@ export interface CachedTalkStatus {
   lastPreparedAt: number | null;
 }
 
+export interface OfflineTalkSummary {
+  _id: string;
+  title: string;
+}
+
+export interface OfflineSetSummary {
+  _id: string;
+  title: string;
+  talkIds: string[];
+}
+
 export interface CachedLibrarySnapshot {
   userId: string;
-  talks: Array<Pick<Doc<'talks'>, '_id' | 'title'>>;
-  sets: Array<Pick<Doc<'talkSets'>, '_id' | 'title' | 'talkIds'>>;
+  talks: OfflineTalkSummary[];
+  sets: OfflineSetSummary[];
   talkStatusById: Record<string, CachedTalkStatus>;
   lastSyncedAt: number;
   schemaVersion: number;
+  syncState: 'ready' | 'partial';
 }
 
 export interface OfflineBootstrapRecord {
@@ -36,7 +48,20 @@ export interface OfflineBootstrapRecord {
   talks: CachedLibrarySnapshot['talks'];
   sets: CachedLibrarySnapshot['sets'];
   talkStatusById: Record<string, CachedTalkStatus>;
+  syncState: 'ready' | 'partial';
 }
+
+export interface OfflineLibraryBundleInput {
+  userId: string;
+  talks: CachedLibrarySnapshot['talks'];
+  sets: CachedLibrarySnapshot['sets'];
+  talkStatusById: Record<string, CachedTalkStatus>;
+}
+
+type LegacyBootstrapRecord = Omit<OfflineBootstrapRecord, 'schemaVersion' | 'syncState'> & {
+  schemaVersion?: number;
+  syncState?: 'ready' | 'partial';
+};
 
 function bootstrapKey(userId: string) {
   return `bootstrap:${userId}`;
@@ -46,6 +71,41 @@ function statusKey(userId: string, talkId: string) {
   return `status:${userId}:${talkId}`;
 }
 
+function normaliseTalkStatus(talkId: string, status?: Partial<CachedTalkStatus>): CachedTalkStatus {
+  return {
+    talkId,
+    hasDocument: status?.hasDocument ?? true,
+    hasAudio: status?.hasAudio ?? false,
+    segmentCount: status?.segmentCount ?? 0,
+    cachedAudioSegments: status?.cachedAudioSegments ?? 0,
+    lastPreparedAt: status?.lastPreparedAt ?? null,
+  };
+}
+
+function normaliseBootstrap(record: LegacyBootstrapRecord | undefined): OfflineBootstrapRecord | undefined {
+  if (!record) return undefined;
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    userId: record.userId,
+    lastSyncedAt: record.lastSyncedAt,
+    library: record.library,
+    talks: record.talks,
+    sets: record.sets,
+    talkStatusById: Object.fromEntries(
+      Object.entries(record.talkStatusById ?? {}).map(([talkId, status]) => [
+        talkId,
+        normaliseTalkStatus(talkId, status),
+      ])
+    ),
+    syncState: record.syncState ?? 'ready',
+  };
+}
+
+async function saveLastUserId(userId: string): Promise<void> {
+  await set('lastUserId', userId, metaStore);
+}
+
 async function getAllTalkPreparedStates(
   userId: string,
   talkIds: string[]
@@ -53,15 +113,15 @@ async function getAllTalkPreparedStates(
   const entries = await Promise.all(
     talkIds.map(async (talkId) => {
       const status = await get<CachedTalkStatus>(statusKey(userId, talkId), statusStore);
-      return [talkId, status] as const;
+      return [talkId, status ? normaliseTalkStatus(talkId, status) : undefined] as const;
     })
   );
 
   return Object.fromEntries(entries.filter((entry): entry is [string, CachedTalkStatus] => !!entry[1]));
 }
 
-async function saveLastUserId(userId: string): Promise<void> {
-  await set('lastUserId', userId, metaStore);
+async function deleteTalkPreparedState(userId: string, talkId: string): Promise<void> {
+  await del(statusKey(userId, talkId), statusStore);
 }
 
 export async function getLastUserId(): Promise<string | undefined> {
@@ -69,29 +129,142 @@ export async function getLastUserId(): Promise<string | undefined> {
 }
 
 export async function saveOfflineBootstrap(record: OfflineBootstrapRecord): Promise<void> {
+  const normalised = normaliseBootstrap(record)!;
   await Promise.all([
-    set(bootstrapKey(record.userId), record, bootstrapStore),
-    saveLastUserId(record.userId),
+    set(bootstrapKey(normalised.userId), normalised, bootstrapStore),
+    saveLastUserId(normalised.userId),
   ]);
 }
 
 export async function getOfflineBootstrap(): Promise<OfflineBootstrapRecord | undefined> {
   const userId = await getLastUserId();
   if (!userId) return undefined;
-  return get<OfflineBootstrapRecord>(bootstrapKey(userId), bootstrapStore);
+  const record = await get<LegacyBootstrapRecord>(bootstrapKey(userId), bootstrapStore);
+  return normaliseBootstrap(record);
+}
+
+export async function refreshOfflineBootstrap(): Promise<OfflineBootstrapRecord | undefined> {
+  return getOfflineBootstrap();
 }
 
 export async function getCachedLibrarySnapshot(userId: string): Promise<CachedLibrarySnapshot | undefined> {
-  const record = await get<OfflineBootstrapRecord>(bootstrapKey(userId), bootstrapStore);
-  if (!record) return undefined;
+  const record = await get<LegacyBootstrapRecord>(bootstrapKey(userId), bootstrapStore);
+  const normalised = normaliseBootstrap(record);
+  if (!normalised) return undefined;
 
   return {
-    userId: record.userId,
-    talks: record.talks,
-    sets: record.sets,
-    talkStatusById: record.talkStatusById,
-    lastSyncedAt: record.lastSyncedAt,
-    schemaVersion: record.schemaVersion,
+    userId: normalised.userId,
+    talks: normalised.talks,
+    sets: normalised.sets,
+    talkStatusById: normalised.talkStatusById,
+    lastSyncedAt: normalised.lastSyncedAt,
+    schemaVersion: normalised.schemaVersion,
+    syncState: normalised.syncState,
+  };
+}
+
+export async function saveOfflineLibraryBundle({
+  userId,
+  talks,
+  sets,
+  talkStatusById,
+}: OfflineLibraryBundleInput): Promise<OfflineBootstrapRecord> {
+  const normalisedStatuses = Object.fromEntries(
+    talks.map((talk) => [talk._id, normaliseTalkStatus(talk._id, talkStatusById[talk._id])])
+  );
+
+  await Promise.all([
+    ...Object.entries(normalisedStatuses).map(([talkId, status]) => set(statusKey(userId, talkId), status, statusStore)),
+    saveLastUserId(userId),
+  ]);
+
+  const record: OfflineBootstrapRecord = {
+    schemaVersion: SCHEMA_VERSION,
+    userId,
+    lastSyncedAt: Date.now(),
+    library: {
+      talkCount: talks.length,
+      setCount: sets.length,
+    },
+    talks,
+    sets,
+    talkStatusById: normalisedStatuses,
+    syncState: 'ready',
+  };
+
+  await saveOfflineBootstrap(record);
+  return record;
+}
+
+export async function pruneOfflineLibraryData(userId: string, liveTalkIds: string[]): Promise<void> {
+  const liveTalkIdSet = new Set(liveTalkIds);
+  const prefixedStatusKeys = await keys<string>(statusStore);
+
+  await Promise.all(
+    prefixedStatusKeys
+      .filter((key) => key.startsWith(`status:${userId}:`))
+      .map(async (key) => {
+        const talkId = key.slice(`status:${userId}:`.length);
+        if (liveTalkIdSet.has(talkId)) return;
+        await deleteTalkPreparedState(userId, talkId);
+      })
+  );
+
+  const cachedTalks = await listTalkData();
+  await Promise.all(
+    cachedTalks
+      .filter((talk) => !liveTalkIdSet.has(talk._id))
+      .map(async (talk) => {
+        await deleteTalkData(talk._id);
+        await clearTalkAudio(talk._id);
+      })
+  );
+}
+
+export async function rebuildOfflineBootstrapFromCachedTalks(
+  userId?: string
+): Promise<OfflineBootstrapRecord | undefined> {
+  const resolvedUserId = userId ?? await getLastUserId();
+  if (!resolvedUserId) return undefined;
+
+  const cachedTalks = await listTalkData();
+  if (cachedTalks.length === 0) return undefined;
+
+  const existingStatuses = await getAllTalkPreparedStates(
+    resolvedUserId,
+    cachedTalks.map((talk) => talk._id)
+  );
+
+  const talkStatusById = Object.fromEntries(
+    cachedTalks.map((talk) => [
+      talk._id,
+      normaliseTalkStatus(talk._id, existingStatuses[talk._id] ?? {
+        hasDocument: true,
+        hasAudio: false,
+        segmentCount: talk.segments.length,
+        cachedAudioSegments: 0,
+        lastPreparedAt: null,
+      }),
+    ])
+  );
+
+  const lastSyncedAt = cachedTalks.reduce((latest, talk) => {
+    const statusPreparedAt = talkStatusById[talk._id]?.lastPreparedAt ?? 0;
+    return Math.max(latest, talk.updatedAt, statusPreparedAt);
+  }, 0) || Date.now();
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    userId: resolvedUserId,
+    lastSyncedAt,
+    library: {
+      talkCount: cachedTalks.length,
+      setCount: 0,
+    },
+    talks: cachedTalks.map((talk) => ({ _id: talk._id, title: talk.title })),
+    sets: [],
+    talkStatusById,
+    syncState: 'partial',
   };
 }
 
@@ -106,14 +279,8 @@ export async function saveLibrarySnapshot(
     Array.from(new Set(talks.map((talk) => talk._id)))
   );
 
-  await saveOfflineBootstrap({
-    schemaVersion: SCHEMA_VERSION,
+  await saveOfflineLibraryBundle({
     userId,
-    lastSyncedAt: Date.now(),
-    library: {
-      talkCount: talks.length,
-      setCount: sets.length,
-    },
     talks,
     sets,
     talkStatusById: resolvedStatuses,
@@ -125,9 +292,13 @@ export async function saveTalkPreparedState(
   talkId: string,
   state: CachedTalkStatus
 ): Promise<void> {
-  await set(statusKey(userId, talkId), state, statusStore);
+  const normalisedState = normaliseTalkStatus(talkId, state);
+  await set(statusKey(userId, talkId), normalisedState, statusStore);
 
-  const currentBootstrap = await get<OfflineBootstrapRecord>(bootstrapKey(userId), bootstrapStore);
+  const currentBootstrap = normaliseBootstrap(
+    await get<LegacyBootstrapRecord>(bootstrapKey(userId), bootstrapStore)
+  );
+
   if (!currentBootstrap) {
     await saveLastUserId(userId);
     return;
@@ -135,9 +306,10 @@ export async function saveTalkPreparedState(
 
   await saveOfflineBootstrap({
     ...currentBootstrap,
+    lastSyncedAt: Date.now(),
     talkStatusById: {
       ...currentBootstrap.talkStatusById,
-      [talkId]: state,
+      [talkId]: normalisedState,
     },
   });
 }
@@ -146,5 +318,12 @@ export async function getTalkPreparedState(
   userId: string,
   talkId: string
 ): Promise<CachedTalkStatus | undefined> {
-  return get<CachedTalkStatus>(statusKey(userId, talkId), statusStore);
+  const status = await get<CachedTalkStatus>(statusKey(userId, talkId), statusStore);
+  return status ? normaliseTalkStatus(talkId, status) : undefined;
+}
+
+async function clearTalkAudio(talkId: string): Promise<void> {
+  const audioKeys = await keys<string>();
+  const talkKeys = audioKeys.filter((key) => key.includes(`:${talkId}:`));
+  await Promise.all(talkKeys.map((key) => del(key)));
 }


### PR DESCRIPTION
## Summary
- replace the opportunistic offline snapshot with a deterministic library sync coordinator
- persist full talk documents from the online library, rebuild offline bootstrap from cached talks, and prune stale offline data
- trust cached talk documents in offline routes and surface explicit offline sync status in the library UI

## Testing
- npm run build
- npm run lint

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added offline library sync status indicator showing real-time sync progress and error states
  * Enhanced offline talk availability detection to recognize cached content alongside synced documents
  * Introduced detail messages for partial offline synchronization states

* **Bug Fixes**
  * Improved offline status badge logic for more accurate availability detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->