### PR TITLE
Fallback to offline routes when live queries stall

### DIFF
--- a/app/library/OnlineLibraryPage.tsx
+++ b/app/library/OnlineLibraryPage.tsx
@@ -10,6 +10,7 @@ import { useOfflineLibrarySync } from '@/hooks/useOfflineLibrarySync';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import { parseFile, splitIntoSentences, joinFullText } from '@/lib/parseFile';
 import { getTalkPreparedState, type CachedTalkStatus } from '@/lib/offlineStore';
+import OfflineLibraryPage from './OfflineLibraryPage';
 
 const PREVIEW_CAP = 100;
 
@@ -26,7 +27,7 @@ interface ImportDraft {
 
 export default function OnlineLibraryPage() {
   const { clerkId } = useOnlineCurrentUser();
-  const { refreshOfflineBootstrap } = useOfflineBoot();
+  const { library, refreshOfflineBootstrap } = useOfflineBoot();
   const [tab, setTab] = useState<Tab>('talks');
   const [createMode, setCreateMode] = useState<CreateMode>('none');
   const [newTalkTitle, setNewTalkTitle] = useState('');
@@ -39,6 +40,7 @@ export default function OnlineLibraryPage() {
   const [assignTalkId, setAssignTalkId] = useState<string | null>(null);
   const [talkStatuses, setTalkStatuses] = useState<Record<string, CachedTalkStatus>>({});
   const [statusesReady, setStatusesReady] = useState(false);
+  const [forceOfflineFallback, setForceOfflineFallback] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const talks = useQuery(api.talks.list, clerkId ? { userId: clerkId } : 'skip');
@@ -58,6 +60,21 @@ export default function OnlineLibraryPage() {
       ? splitIntoSentences(importDraft.paragraphs)
       : importDraft.paragraphs;
   }, [importDraft]);
+
+  useEffect(() => {
+    if (talks !== undefined && sets !== undefined) {
+      setForceOfflineFallback(false);
+      return;
+    }
+
+    if (!library) return;
+
+    const timeout = setTimeout(() => {
+      setForceOfflineFallback(true);
+    }, 2500);
+
+    return () => clearTimeout(timeout);
+  }, [library, sets, talks]);
 
   useEffect(() => {
     if (!clerkId || !talks) {
@@ -191,6 +208,10 @@ export default function OnlineLibraryPage() {
     : syncState === 'error'
       ? 'text-red-400'
       : 'text-[var(--muted)]';
+
+  if (forceOfflineFallback && library) {
+    return <OfflineLibraryPage />;
+  }
 
   return (
     <div className="flex flex-col min-h-dvh bg-[var(--background)] text-[var(--foreground)]">

--- a/app/talk/[id]/OnlineTalkPage.tsx
+++ b/app/talk/[id]/OnlineTalkPage.tsx
@@ -4,17 +4,20 @@ import { use, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
+import { useOfflineBoot } from '@/hooks/useOfflineBoot';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import { getCachedAudio, saveTalkData, setCachedAudio } from '@/lib/audioStore';
 import { getTalkPreparedState, saveTalkPreparedState } from '@/lib/offlineStore';
 import { buildSSML, SegmentElement } from '@/lib/ssml';
 import { fetchTTSBlob, TTSConfig } from '@/lib/tts';
+import OfflineTalkPage from './OfflineTalkPage';
 
 type SpeakState = 'idle' | 'loading' | 'speaking' | 'spoken';
 
 export default function OnlineTalkPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { clerkId } = useOnlineCurrentUser();
+  const { library } = useOfflineBoot();
 
   const talk = useQuery(api.talks.get, { id: id as Id<'talks'> });
   const settings = useQuery(api.users.getSettings, clerkId ? { clerkId } : 'skip');
@@ -27,6 +30,7 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
   const [cacheReady, setCacheReady] = useState(false);
   const [cacheFailed, setCacheFailed] = useState(false);
   const [cacheChecked, setCacheChecked] = useState(false);
+  const [forceOfflineFallback, setForceOfflineFallback] = useState(false);
 
   const provider = settings?.provider ?? 'elevenlabs';
   const isAzure = provider === 'azure';
@@ -49,6 +53,21 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
   const effectiveTalk = talk ?? undefined;
   const segments = useMemo(() => effectiveTalk?.segments ?? [], [effectiveTalk]);
   const voiceKey = `${provider}:${settings?.voiceId ?? 'default'}`;
+
+  useEffect(() => {
+    if (talk !== undefined) {
+      setForceOfflineFallback(false);
+      return;
+    }
+
+    if (!library) return;
+
+    const timeout = setTimeout(() => {
+      setForceOfflineFallback(true);
+    }, 2500);
+
+    return () => clearTimeout(timeout);
+  }, [library, talk]);
 
   useEffect(() => {
     if (!talk) return;
@@ -228,6 +247,10 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
     audioRef.current = null;
     setSpeakState('idle');
     setIndex((prev) => prev - 1);
+  }
+
+  if (forceOfflineFallback && library) {
+    return <OfflineTalkPage params={params} />;
   }
 
   if (effectiveTalk === undefined) {


### PR DESCRIPTION
## Summary
- detect when the online library route is stuck waiting for live queries and fall back to cached offline content
- do the same for the talk route so cached talks open instead of hanging on the online query

## Testing
- npm run build
- npm run lint

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced intelligent offline fallback mechanism to enhance reliability. When live content is unavailable or takes longer than 2.5 seconds to load, the app automatically switches to offline library content, ensuring seamless browsing and preventing disruptions across all pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->