### PR TITLE
Centralize offline gates and talk maintenance helpers

### DIFF
--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,26 +1,19 @@
 'use client';
 
 import { SignIn } from '@clerk/nextjs';
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 
 export default function SignInPage() {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency' || mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="Sign in requires a connection"
-        message="Podium cannot sign in while offline. Reconnect to continue."
-        href="/library"
-        actionLabel="Back to library"
-      />
-    );
-  }
-
   return (
-    <div className="flex min-h-dvh items-center justify-center">
-      <SignIn />
-    </div>
+    <OfflineGate
+      unavailableTitle="Sign in requires a connection"
+      unavailableMessage="Podium cannot sign in while offline. Reconnect to continue."
+      href="/library"
+      actionLabel="Back to library"
+    >
+      <div className="flex min-h-dvh items-center justify-center">
+        <SignIn />
+      </div>
+    </OfflineGate>
   );
 }

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,26 +1,19 @@
 'use client';
 
 import { SignUp } from '@clerk/nextjs';
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 
 export default function SignUpPage() {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency' || mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="Sign up requires a connection"
-        message="Podium cannot create an account while offline. Reconnect to continue."
-        href="/library"
-        actionLabel="Back to library"
-      />
-    );
-  }
-
   return (
-    <div className="flex min-h-dvh items-center justify-center">
-      <SignUp />
-    </div>
+    <OfflineGate
+      unavailableTitle="Sign up requires a connection"
+      unavailableMessage="Podium cannot create an account while offline. Reconnect to continue."
+      href="/library"
+      actionLabel="Back to library"
+    >
+      <div className="flex min-h-dvh items-center justify-center">
+        <SignUp />
+      </div>
+    </OfflineGate>
   );
 }

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,25 +1,17 @@
 'use client';
 
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
-import OnlineLibraryPage from './OnlineLibraryPage';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 import OfflineLibraryPage from './OfflineLibraryPage';
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
+import OnlineLibraryPage from './OnlineLibraryPage';
 
 export default function LibraryPage() {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency') {
-    return <OfflineLibraryPage />;
-  }
-
-  if (mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="Offline library unavailable"
-        message="Connect once and open your library online before Podium can show your talks offline."
-      />
-    );
-  }
-
-  return <OnlineLibraryPage />;
+  return (
+    <OfflineGate
+      emergency={<OfflineLibraryPage />}
+      unavailableTitle="Offline library unavailable"
+      unavailableMessage="Connect once and open your library online before Podium can show your talks offline."
+    >
+      <OnlineLibraryPage />
+    </OfflineGate>
+  );
 }

--- a/app/set/[id]/page.tsx
+++ b/app/set/[id]/page.tsx
@@ -4,23 +4,18 @@ import { use, useState } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 
 export default function SetPage({ params }: { params: Promise<{ id: string }> }) {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency' || mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="Sets unavailable offline"
-        message="Set details are not available in Podium's offline emergency mode yet."
-      />
-    );
-  }
-
-  return <OnlineSetPage params={params} />;
+  return (
+    <OfflineGate
+      unavailableTitle="Sets unavailable offline"
+      unavailableMessage="Set details are not available in Podium's offline emergency mode yet."
+    >
+      <OnlineSetPage params={params} />
+    </OfflineGate>
+  );
 }
 
 function OnlineSetPage({ params }: { params: Promise<{ id: string }> }) {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,26 +3,21 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import { fetchVoices, TTSConfig, TTSVoice, DEFAULT_VOICE_ID } from '@/lib/tts';
 
 const MASKED = '••••••••••••••••';
 
 export default function SettingsPage() {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency' || mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="Settings unavailable offline"
-        message="Settings require a live connection and are not part of Podium's offline emergency mode."
-      />
-    );
-  }
-
-  return <OnlineSettingsPage />;
+  return (
+    <OfflineGate
+      unavailableTitle="Settings unavailable offline"
+      unavailableMessage="Settings require a live connection and are not part of Podium's offline emergency mode."
+    >
+      <OnlineSettingsPage />
+    </OfflineGate>
+  );
 }
 
 function OnlineSettingsPage() {

--- a/app/talk/[id]/edit/page.tsx
+++ b/app/talk/[id]/edit/page.tsx
@@ -4,28 +4,22 @@ import { use, useState, useEffect, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import { splitIntoSentences, joinFullText } from '@/lib/parseFile';
-import { clearTalkAudio, saveTalkData } from '@/lib/audioStore';
-import { saveTalkPreparedState } from '@/lib/offlineStore';
+import { invalidateTalkOfflineState } from '@/lib/offlineTalkMaintenance';
 
 type SegmentMode = 'paragraphs' | 'sentences';
 
 export default function EditPage({ params }: { params: Promise<{ id: string }> }) {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency' || mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="Editing unavailable offline"
-        message="Talk editing is not available in Podium's offline emergency mode."
-      />
-    );
-  }
-
-  return <OnlineEditPage params={params} />;
+  return (
+    <OfflineGate
+      unavailableTitle="Editing unavailable offline"
+      unavailableMessage="Talk editing is not available in Podium's offline emergency mode."
+    >
+      <OnlineEditPage params={params} />
+    </OfflineGate>
+  );
 }
 
 function OnlineEditPage({ params }: { params: Promise<{ id: string }> }) {
@@ -73,23 +67,12 @@ function OnlineEditPage({ params }: { params: Promise<{ id: string }> }) {
         segments,
         segmentMode: mode,
       });
-      await saveTalkData(id, {
-        _id: id,
+      await invalidateTalkOfflineState({
+        userId: clerkId,
+        talkId: id,
         title: talk?.title ?? 'Untitled',
         segments,
-        updatedAt: Date.now(),
       });
-      await clearTalkAudio(id);
-      if (clerkId) {
-        await saveTalkPreparedState(clerkId, id, {
-          talkId: id,
-          hasDocument: true,
-          hasAudio: false,
-          segmentCount: segments.length,
-          cachedAudioSegments: 0,
-          lastPreparedAt: null,
-        });
-      }
       setDirty(false);
       setSaved(true);
     } catch {

--- a/app/talk/[id]/history/page.tsx
+++ b/app/talk/[id]/history/page.tsx
@@ -5,27 +5,21 @@ import { useQuery, useMutation } from 'convex/react';
 import { diffWords } from 'diff';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
-import { clearTalkAudio, saveTalkData } from '@/lib/audioStore';
-import { saveTalkPreparedState } from '@/lib/offlineStore';
+import { invalidateTalkOfflineState } from '@/lib/offlineTalkMaintenance';
 
 type ViewMode = 'preview' | 'diff';
 
 export default function HistoryPage({ params }: { params: Promise<{ id: string }> }) {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency' || mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="History unavailable offline"
-        message="Version history is not available in Podium's offline emergency mode."
-      />
-    );
-  }
-
-  return <OnlineHistoryPage params={params} />;
+  return (
+    <OfflineGate
+      unavailableTitle="History unavailable offline"
+      unavailableMessage="Version history is not available in Podium's offline emergency mode."
+    >
+      <OnlineHistoryPage params={params} />
+    </OfflineGate>
+  );
 }
 
 function OnlineHistoryPage({ params }: { params: Promise<{ id: string }> }) {
@@ -48,22 +42,11 @@ function OnlineHistoryPage({ params }: { params: Promise<{ id: string }> }) {
       await restoreVersion({ talkId: id as Id<'talks'>, versionId, userId: clerkId });
       const restoredVersion = versions?.find((version) => version._id === versionId);
       if (restoredVersion && talk) {
-        await saveTalkData(id, {
-          _id: id,
+        await invalidateTalkOfflineState({
+          userId: clerkId,
+          talkId: id,
           title: talk.title,
           segments: restoredVersion.segments,
-          updatedAt: Date.now(),
-        });
-      }
-      await clearTalkAudio(id);
-      if (talk) {
-        await saveTalkPreparedState(clerkId, id, {
-          talkId: id,
-          hasDocument: true,
-          hasAudio: false,
-          segmentCount: talk.segments.length,
-          cachedAudioSegments: 0,
-          lastPreparedAt: null,
         });
       }
       setRestored(versionId);

--- a/app/talk/[id]/page.tsx
+++ b/app/talk/[id]/page.tsx
@@ -1,25 +1,17 @@
 'use client';
 
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 import OfflineTalkPage from './OfflineTalkPage';
 import OnlineTalkPage from './OnlineTalkPage';
 
 export default function TalkPage({ params }: { params: Promise<{ id: string }> }) {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency') {
-    return <OfflineTalkPage params={params} />;
-  }
-
-  if (mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="Offline talk unavailable"
-        message="Connect once and open your library online before Podium can present talks offline."
-      />
-    );
-  }
-
-  return <OnlineTalkPage params={params} />;
+  return (
+    <OfflineGate
+      emergency={<OfflineTalkPage params={params} />}
+      unavailableTitle="Offline talk unavailable"
+      unavailableMessage="Connect once and open your library online before Podium can present talks offline."
+    >
+      <OnlineTalkPage params={params} />
+    </OfflineGate>
+  );
 }

--- a/app/talk/[id]/segments/page.tsx
+++ b/app/talk/[id]/segments/page.tsx
@@ -4,8 +4,7 @@ import { use, useState, useCallback, useRef } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
-import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
-import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineGate } from '@/components/offline/OfflineGate';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import {
   SegmentElement,
@@ -16,8 +15,7 @@ import {
   tokenise,
 } from '@/lib/ssml';
 import { fetchTTSBlob, TTSConfig } from '@/lib/tts';
-import { clearTalkAudio, saveTalkData } from '@/lib/audioStore';
-import { saveTalkPreparedState } from '@/lib/offlineStore';
+import { invalidateTalkOfflineState } from '@/lib/offlineTalkMaintenance';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -383,18 +381,14 @@ function SegmentBrickEditor({
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function SegmentsPage({ params }: { params: Promise<{ id: string }> }) {
-  const { mode } = useOfflineBoot();
-
-  if (mode === 'offline-emergency' || mode === 'offline-unavailable') {
-    return (
-      <OfflineUnavailable
-        title="Segments unavailable offline"
-        message="The segment editor is not available in Podium's offline emergency mode."
-      />
-    );
-  }
-
-  return <OnlineSegmentsPage params={params} />;
+  return (
+    <OfflineGate
+      unavailableTitle="Segments unavailable offline"
+      unavailableMessage="The segment editor is not available in Podium's offline emergency mode."
+    >
+      <OnlineSegmentsPage params={params} />
+    </OfflineGate>
+  );
 }
 
 function OnlineSegmentsPage({ params }: { params: Promise<{ id: string }> }) {
@@ -420,24 +414,13 @@ function OnlineSegmentsPage({ params }: { params: Promise<{ id: string }> }) {
       if (!clerkId) return;
       await saveSegmentElements({ id: id as Id<'talks'>, userId: clerkId, segmentId, elements });
       if (talk) {
-        await saveTalkData(id, {
-          _id: id,
+        await invalidateTalkOfflineState({
+          userId: clerkId,
+          talkId: id,
           title: talk.title,
           segments: talk.segments.map((segment) => (
             segment.id === segmentId ? { ...segment, elements } : segment
           )),
-          updatedAt: Date.now(),
-        });
-      }
-      await clearTalkAudio(id);
-      if (talk) {
-        await saveTalkPreparedState(clerkId, id, {
-          talkId: id,
-          hasDocument: true,
-          hasAudio: false,
-          segmentCount: talk.segments.length,
-          cachedAudioSegments: 0,
-          lastPreparedAt: null,
         });
       }
     },

--- a/components/offline/OfflineGate.tsx
+++ b/components/offline/OfflineGate.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useOfflineBoot } from '@/hooks/useOfflineBoot';
+import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
+
+interface OfflineGateProps {
+  children: React.ReactNode;
+  unavailableTitle: string;
+  unavailableMessage: string;
+  href?: string;
+  actionLabel?: string;
+  emergency?: React.ReactNode;
+}
+
+export function OfflineGate({
+  children,
+  unavailableTitle,
+  unavailableMessage,
+  href,
+  actionLabel,
+  emergency,
+}: OfflineGateProps) {
+  const { mode } = useOfflineBoot();
+
+  if (mode === 'offline-emergency') {
+    return emergency ?? (
+      <OfflineUnavailable
+        title={unavailableTitle}
+        message={unavailableMessage}
+        href={href}
+        actionLabel={actionLabel}
+      />
+    );
+  }
+
+  if (mode === 'offline-unavailable') {
+    return (
+      <OfflineUnavailable
+        title={unavailableTitle}
+        message={unavailableMessage}
+        href={href}
+        actionLabel={actionLabel}
+      />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/lib/offlineTalkMaintenance.ts
+++ b/lib/offlineTalkMaintenance.ts
@@ -1,0 +1,61 @@
+import { clearTalkAudio, saveTalkData } from '@/lib/audioStore';
+import { saveTalkPreparedState } from '@/lib/offlineStore';
+
+interface ReplaceCachedTalkDocumentArgs {
+  talkId: string;
+  title: string;
+  segments: Array<{ id: string; text: string; elements?: unknown[] }>;
+  voiceKey?: string;
+}
+
+interface MarkTalkDocumentOnlyArgs {
+  userId: string;
+  talkId: string;
+  segmentCount: number;
+}
+
+interface InvalidateTalkOfflineStateArgs extends ReplaceCachedTalkDocumentArgs {
+  userId: string;
+}
+
+export async function replaceCachedTalkDocument({
+  talkId,
+  title,
+  segments,
+  voiceKey,
+}: ReplaceCachedTalkDocumentArgs): Promise<void> {
+  await saveTalkData(talkId, {
+    _id: talkId,
+    title,
+    segments,
+    voiceKey,
+    updatedAt: Date.now(),
+  });
+}
+
+export async function markTalkDocumentOnly({
+  userId,
+  talkId,
+  segmentCount,
+}: MarkTalkDocumentOnlyArgs): Promise<void> {
+  await saveTalkPreparedState(userId, talkId, {
+    talkId,
+    hasDocument: true,
+    hasAudio: false,
+    segmentCount,
+    cachedAudioSegments: 0,
+    lastPreparedAt: null,
+  });
+}
+
+export async function invalidateTalkOfflineState({
+  userId,
+  talkId,
+  title,
+  segments,
+  voiceKey,
+}: InvalidateTalkOfflineStateArgs): Promise<void> {
+  await replaceCachedTalkDocument({ talkId, title, segments, voiceKey });
+  await clearTalkAudio(talkId);
+  await markTalkDocumentOnly({ userId, talkId, segmentCount: segments.length });
+}


### PR DESCRIPTION
## Summary
- add a shared OfflineGate component for repeated offline route handling
- add shared talk offline-maintenance helpers for cached document replacement and readiness invalidation
- update existing routes to use the shared helpers without changing behavior

## Testing
- npm run build
- npm run lint

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized offline mode handling across authentication, library, settings, and talk pages for consistent offline experience.
  * Improved offline state management for edited and restored talks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->