### PR TITLE
Split online library page into focused UI components

### DIFF
--- a/app/library/OnlineLibraryPage.tsx
+++ b/app/library/OnlineLibraryPage.tsx
@@ -2,33 +2,32 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery } from 'convex/react';
+import { AssignTalkSheet } from '@/components/library/AssignTalkSheet';
+import { ImportTalkSheet } from '@/components/library/ImportTalkSheet';
+import { LibraryFab } from '@/components/library/LibraryFab';
+import { LibraryHeader } from '@/components/library/LibraryHeader';
+import { LibraryTabs } from '@/components/library/LibraryTabs';
+import { SetList } from '@/components/library/SetList';
+import { TalkList } from '@/components/library/TalkList';
+import {
+  CreateMode,
+  ImportDraft,
+  LibraryTab,
+  SegmentMode,
+} from '@/components/library/libraryTypes';
 import { api } from '@/convex/_generated/api';
-import { Doc, Id } from '@/convex/_generated/dataModel';
-import { OfflineStatusBadge } from '@/components/offline/OfflineStatusBadge';
+import { Id } from '@/convex/_generated/dataModel';
 import { useOfflineBoot } from '@/hooks/useOfflineBoot';
 import { useOfflineLibrarySync } from '@/hooks/useOfflineLibrarySync';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import { parseFile, splitIntoSentences, joinFullText } from '@/lib/parseFile';
-import { getTalkPreparedState, type CachedTalkStatus } from '@/lib/offlineStore';
+import { CachedTalkStatus, getTalkPreparedState } from '@/lib/offlineStore';
 import OfflineLibraryPage from './OfflineLibraryPage';
-
-const PREVIEW_CAP = 100;
-
-type Tab = 'talks' | 'sets';
-type CreateMode = 'none' | 'new' | 'set';
-type SegmentMode = 'paragraphs' | 'sentences';
-
-interface ImportDraft {
-  title: string;
-  fullText: string;
-  paragraphs: string[];
-  mode: SegmentMode;
-}
 
 export default function OnlineLibraryPage() {
   const { clerkId } = useOnlineCurrentUser();
   const { library, refreshOfflineBootstrap } = useOfflineBoot();
-  const [tab, setTab] = useState<Tab>('talks');
+  const [tab, setTab] = useState<LibraryTab>('talks');
   const [createMode, setCreateMode] = useState<CreateMode>('none');
   const [newTalkTitle, setNewTalkTitle] = useState('');
   const [newSetTitle, setNewSetTitle] = useState('');
@@ -56,6 +55,7 @@ export default function OnlineLibraryPage() {
 
   const previewSegments = useMemo(() => {
     if (!importDraft) return [];
+
     return importDraft.mode === 'sentences'
       ? splitIntoSentences(importDraft.paragraphs)
       : importDraft.paragraphs;
@@ -123,7 +123,9 @@ export default function OnlineLibraryPage() {
     refreshOfflineBootstrap,
   });
 
-  function closeFab() { setFabOpen(false); }
+  function closeFab() {
+    setFabOpen(false);
+  }
 
   function openNew() {
     closeFab();
@@ -136,10 +138,13 @@ export default function OnlineLibraryPage() {
     setTimeout(() => fileInputRef.current?.click(), 50);
   }
 
-  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
+  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
     if (!file) return;
-    if (fileInputRef.current) fileInputRef.current.value = '';
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
 
     setImportError('');
 
@@ -153,8 +158,8 @@ export default function OnlineLibraryPage() {
         paragraphs,
         mode: 'paragraphs',
       });
-    } catch (err) {
-      setImportError(err instanceof Error ? err.message : 'Failed to read file.');
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : 'Failed to read file.');
     }
   }
 
@@ -163,7 +168,7 @@ export default function OnlineLibraryPage() {
 
     setImporting(true);
     try {
-      const segments = previewSegments.map((text, i) => ({ id: String(i), text }));
+      const segments = previewSegments.map((text, index) => ({ id: String(index), text }));
       await createTalkWithSegments({
         userId: clerkId,
         title: importDraft.title.trim() || 'Untitled',
@@ -179,326 +184,152 @@ export default function OnlineLibraryPage() {
     }
   }
 
-  async function handleCreateTalk(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleCreateTalk(event: React.FormEvent) {
+    event.preventDefault();
     if (!clerkId || !newTalkTitle.trim()) return;
+
     await createTalk({ userId: clerkId, title: newTalkTitle.trim() });
     setNewTalkTitle('');
     setCreateMode('none');
   }
 
-  async function handleCreateSet(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleCreateSet(event: React.FormEvent) {
+    event.preventDefault();
     if (!clerkId || !newSetTitle.trim()) return;
+
     await createSet({ userId: clerkId, title: newSetTitle.trim() });
     setNewSetTitle('');
     setCreateMode('none');
   }
 
-  const syncLabel = syncState === 'syncing'
-    ? 'Syncing offline data...'
-    : syncState === 'ready'
-      ? 'Available offline'
-      : syncState === 'error'
-        ? 'Offline sync failed'
-        : 'Preparing offline data...';
+  function handleDeleteTalk(talkId: string) {
+    if (!clerkId) return;
 
-  const syncClassName = syncState === 'ready'
-    ? 'text-emerald-400'
-    : syncState === 'error'
-      ? 'text-red-400'
-      : 'text-[var(--muted)]';
+    void removeTalk({ id: talkId as Id<'talks'>, userId: clerkId });
+    setConfirmDeleteId(null);
+  }
+
+  function handleDeleteSet(setId: string) {
+    if (!clerkId) return;
+
+    void removeSet({ id: setId as Id<'talkSets'>, userId: clerkId });
+    setConfirmDeleteId(null);
+  }
+
+  function handleToggleSetMembership(setId: Id<'talkSets'>, inSet: boolean) {
+    if (!clerkId || !assignTalkId) return;
+
+    if (inSet) {
+      void removeTalkFromSet({ id: setId, userId: clerkId, talkId: assignTalkId as Id<'talks'> });
+      return;
+    }
+
+    void addTalkToSet({ id: setId, userId: clerkId, talkId: assignTalkId as Id<'talks'> });
+  }
+
+  const syncLabel =
+    syncState === 'syncing'
+      ? 'Syncing offline data...'
+      : syncState === 'ready'
+        ? 'Available offline'
+        : syncState === 'error'
+          ? 'Offline sync failed'
+          : 'Preparing offline data...';
+
+  const syncClassName =
+    syncState === 'ready'
+      ? 'text-emerald-400'
+      : syncState === 'error'
+        ? 'text-red-400'
+        : 'text-[var(--muted)]';
 
   if (forceOfflineFallback && library) {
     return <OfflineLibraryPage />;
   }
 
   return (
-    <div className="flex flex-col min-h-dvh bg-[var(--background)] text-[var(--foreground)]">
-      <header className="flex items-center justify-between px-5 pt-6 pb-4 border-b border-[var(--border)]">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight" style={{ fontFamily: 'var(--font-display)' }}>Podium</h1>
-          <p className={`mt-1 text-xs ${syncClassName}`} title={syncError ?? undefined}>
-            {syncLabel}
-          </p>
-        </div>
-        <a href="/settings" className="text-sm text-[var(--muted)] hover:text-[var(--foreground)]">
-          Settings
-        </a>
-      </header>
+    <div className="flex min-h-dvh flex-col bg-[var(--background)] text-[var(--foreground)]">
+      <LibraryHeader
+        syncClassName={syncClassName}
+        syncError={syncError}
+        syncLabel={syncLabel}
+      />
 
-      <div className="flex border-b border-[var(--border)]">
-        {(['talks', 'sets'] as Tab[]).map((t) => (
-          <button
-            key={t}
-            onClick={() => setTab(t)}
-            className={`flex-1 py-3 text-sm font-medium capitalize transition-colors ${
-              tab === t
-                ? 'text-[var(--primary)] border-b-2 border-[var(--primary)]'
-                : 'text-[var(--muted)]'
-            }`}
-          >
-            {t}
-          </button>
-        ))}
-      </div>
+      <LibraryTabs activeTab={tab} onTabChange={setTab} />
 
-      <main className="flex-1 overflow-y-auto px-4 py-4 space-y-3 pb-24">
-        {tab === 'talks' && (
-          <>
-            {talks === undefined && <p className="text-center text-[var(--muted)] py-8">Loading...</p>}
-            {talks?.length === 0 && createMode === 'none' && (
-              <p className="text-center text-[var(--muted)] py-12 text-sm">No talks yet. Tap + to create your first.</p>
-            )}
-            {talks?.map((talk: Doc<'talks'>) => (
-              <div key={talk._id} className="flex items-center justify-between bg-[var(--surface)] hover:bg-[var(--surface-hover)] rounded-xl px-4 py-4 gap-3 transition-colors">
-                <div className="min-w-0 flex-1">
-                  <a href={`/talk/${talk._id}`} className="block truncate font-medium text-[var(--foreground)]">
-                    {talk.title}
-                  </a>
-                  <div className="mt-2">
-                    <OfflineStatusBadge
-                      status={talkStatuses[talk._id]}
-                      documentAvailable
-                    />
-                  </div>
-                </div>
-                <div className="flex items-center gap-1 shrink-0">
-                  {sets && sets.length > 0 && (
-                    <button
-                      onClick={() => setAssignTalkId(talk._id)}
-                      className="text-[var(--muted)] hover:text-[var(--primary)] text-lg px-2 py-1 rounded transition-colors leading-none"
-                      title="Add to set"
-                    >
-                      +
-                    </button>
-                  )}
-                  {confirmDeleteId === talk._id ? (
-                    <>
-                      <button
-                        onClick={() => {
-                          if (!clerkId) return;
-                          void removeTalk({ id: talk._id as Id<'talks'>, userId: clerkId });
-                          setConfirmDeleteId(null);
-                        }}
-                        className="text-red-400 text-xs px-2 py-1 rounded transition-colors"
-                      >
-                        Confirm
-                      </button>
-                      <button onClick={() => setConfirmDeleteId(null)} className="text-[var(--muted)] text-xs px-2 py-1 rounded transition-colors">
-                        Cancel
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      onClick={() => setConfirmDeleteId(talk._id)}
-                      className="text-[var(--muted)] hover:text-red-400 text-xs px-2 py-1 rounded transition-colors"
-                    >
-                      Delete
-                    </button>
-                  )}
-                </div>
-              </div>
-            ))}
-            {createMode === 'new' && (
-              <form onSubmit={handleCreateTalk} className="flex gap-2">
-                <input
-                  autoFocus
-                  value={newTalkTitle}
-                  onChange={(e) => setNewTalkTitle(e.target.value)}
-                  placeholder="Talk title"
-                  className="flex-1 bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] placeholder-[var(--muted)] outline-none border border-[var(--border)] focus:border-[var(--primary)]"
-                />
-                <button type="submit" className="bg-[var(--primary)] text-white rounded-xl px-4 py-3 text-sm font-medium">Add</button>
-                <button type="button" onClick={() => setCreateMode('none')} className="text-[var(--muted)] px-3 py-3 text-sm">Cancel</button>
-              </form>
-            )}
-            {importError && <p className="text-center text-red-400 py-2 text-sm">{importError}</p>}
-          </>
-        )}
-
-        {tab === 'sets' && (
-          <>
-            {sets === undefined && <p className="text-center text-[var(--muted)] py-8">Loading...</p>}
-            {sets?.length === 0 && createMode === 'none' && (
-              <p className="text-center text-[var(--muted)] py-12 text-sm">No sets yet. Group talks for an event.</p>
-            )}
-            {sets?.map((set: Doc<'talkSets'>) => (
-              <div key={set._id} className="bg-[var(--surface)] hover:bg-[var(--surface-hover)] rounded-xl px-4 py-4 transition-colors">
-                <div className="flex items-center justify-between">
-                  <a href={`/set/${set._id}`} className="flex-1 font-medium text-[var(--foreground)]">{set.title}</a>
-                  {confirmDeleteId === set._id ? (
-                    <div className="flex items-center gap-2 shrink-0">
-                      <button
-                        onClick={() => {
-                          if (!clerkId) return;
-                          void removeSet({ id: set._id as Id<'talkSets'>, userId: clerkId });
-                          setConfirmDeleteId(null);
-                        }}
-                        className="text-red-400 text-xs px-2 py-1 rounded transition-colors"
-                      >
-                        Confirm
-                      </button>
-                      <button onClick={() => setConfirmDeleteId(null)} className="text-[var(--muted)] text-xs px-2 py-1 rounded transition-colors">
-                        Cancel
-                      </button>
-                    </div>
-                  ) : (
-                    <button
-                      onClick={() => setConfirmDeleteId(set._id)}
-                      className="text-[var(--muted)] hover:text-red-400 text-xs px-2 py-1 rounded transition-colors"
-                    >
-                      Delete
-                    </button>
-                  )}
-                </div>
-                <p className="text-xs text-[var(--muted)] mt-1">
-                  {set.talkIds.length} {set.talkIds.length === 1 ? 'talk' : 'talks'}
-                </p>
-              </div>
-            ))}
-            {createMode === 'set' && (
-              <form onSubmit={handleCreateSet} className="flex gap-2">
-                <input
-                  autoFocus
-                  value={newSetTitle}
-                  onChange={(e) => setNewSetTitle(e.target.value)}
-                  placeholder="Set title (e.g. Conference 2026)"
-                  className="flex-1 bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] placeholder-[var(--muted)] outline-none border border-[var(--border)] focus:border-[var(--primary)]"
-                />
-                <button type="submit" className="bg-[var(--primary)] text-white rounded-xl px-4 py-3 text-sm font-medium">Add</button>
-                <button type="button" onClick={() => setCreateMode('none')} className="text-[var(--muted)] px-3 py-3 text-sm">Cancel</button>
-              </form>
-            )}
-          </>
+      <main className="flex-1 space-y-3 overflow-y-auto px-4 py-4 pb-24">
+        {tab === 'talks' ? (
+          <TalkList
+            confirmDeleteId={confirmDeleteId}
+            createMode={createMode}
+            importError={importError}
+            newTalkTitle={newTalkTitle}
+            setsAvailable={(sets?.length ?? 0) > 0}
+            talkStatuses={talkStatuses}
+            talks={talks}
+            onAssignRequest={setAssignTalkId}
+            onCancelCreate={() => setCreateMode('none')}
+            onCreateTalk={handleCreateTalk}
+            onDeleteCancel={() => setConfirmDeleteId(null)}
+            onDeleteConfirm={handleDeleteTalk}
+            onDeleteRequest={setConfirmDeleteId}
+            onNewTalkTitleChange={setNewTalkTitle}
+          />
+        ) : (
+          <SetList
+            confirmDeleteId={confirmDeleteId}
+            createMode={createMode}
+            newSetTitle={newSetTitle}
+            sets={sets}
+            onCancelCreate={() => setCreateMode('none')}
+            onCreateSet={handleCreateSet}
+            onDeleteCancel={() => setConfirmDeleteId(null)}
+            onDeleteConfirm={handleDeleteSet}
+            onDeleteRequest={setConfirmDeleteId}
+            onNewSetTitleChange={setNewSetTitle}
+          />
         )}
       </main>
 
-      <input ref={fileInputRef} type="file" accept=".docx,.pdf" className="hidden" onChange={handleFileChange} />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".docx,.pdf"
+        className="hidden"
+        onChange={handleFileChange}
+      />
 
-      {fabOpen && <div className="fixed inset-0 z-10" onClick={closeFab} />}
+      <LibraryFab
+        fabOpen={fabOpen}
+        tab={tab}
+        onClose={closeFab}
+        onOpenImport={openImport}
+        onOpenNew={openNew}
+        onToggle={() => setFabOpen((value) => !value)}
+      />
 
-      <div className="fixed bottom-6 right-5 z-20 flex flex-col items-end gap-3">
-        {fabOpen && tab === 'talks' && (
-          <>
-            <button
-              onClick={openImport}
-              className="flex items-center gap-3 bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground)] rounded-2xl px-4 py-3 text-sm font-medium shadow-lg whitespace-nowrap"
-            >
-              Import file
-              <span className="text-[var(--muted)] text-xs">.docx / .pdf</span>
-            </button>
-            <button
-              onClick={openNew}
-              className="flex items-center gap-3 bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground)] rounded-2xl px-4 py-3 text-sm font-medium shadow-lg"
-            >
-              New talk
-            </button>
-          </>
-        )}
-        <button
-          onClick={() => { if (tab === 'sets') openNew(); else setFabOpen((v) => !v); }}
-          className={`w-14 h-14 rounded-full bg-[var(--primary)] text-white text-2xl flex items-center justify-center shadow-lg transition-transform ${fabOpen ? 'rotate-45' : ''} active:scale-95`}
-        >
-          +
-        </button>
-      </div>
+      <ImportTalkSheet
+        importDraft={importDraft}
+        importing={importing}
+        previewSegments={previewSegments}
+        onClose={() => setImportDraft(null)}
+        onConfirm={handleConfirmImport}
+        onModeChange={(mode: SegmentMode) => {
+          if (!importDraft) return;
+          setImportDraft({ ...importDraft, mode });
+        }}
+        onTitleChange={(title) => {
+          if (!importDraft) return;
+          setImportDraft({ ...importDraft, title });
+        }}
+      />
 
-      {importDraft && (
-        <>
-          <div className="fixed inset-0 z-30 bg-black/60" onClick={() => setImportDraft(null)} />
-          <div className="fixed bottom-0 left-0 right-0 z-40 bg-[var(--background)] rounded-t-2xl max-h-[85dvh] flex flex-col">
-            <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-[var(--border)] shrink-0">
-              <button onClick={() => setImportDraft(null)} className="text-[var(--muted)] text-sm">Cancel</button>
-              <span className="text-sm font-semibold">Import talk</span>
-              <button
-                onClick={handleConfirmImport}
-                disabled={importing}
-                className="text-[var(--primary)] text-sm font-semibold disabled:opacity-40"
-              >
-                {importing ? 'Saving...' : 'Import'}
-              </button>
-            </div>
-
-            <div className="px-5 py-3 border-b border-[var(--border)] shrink-0">
-              <input
-                value={importDraft.title}
-                onChange={(e) => setImportDraft({ ...importDraft, title: e.target.value })}
-                className="w-full bg-transparent text-base font-medium text-[var(--foreground)] outline-none placeholder-[var(--muted)]"
-                placeholder="Talk title"
-              />
-            </div>
-
-            <div className="flex items-center gap-1 px-5 py-3 border-b border-[var(--border)] shrink-0">
-              <span className="text-xs text-[var(--muted)] mr-2">Split by</span>
-              {(['paragraphs', 'sentences'] as SegmentMode[]).map((m) => (
-                <button
-                  key={m}
-                  onClick={() => setImportDraft({ ...importDraft, mode: m })}
-                  className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors capitalize ${
-                    importDraft.mode === m
-                      ? 'bg-[var(--primary)] text-white'
-                      : 'bg-[var(--surface)] text-[var(--muted)]'
-                  }`}
-                >
-                  {m}
-                </button>
-              ))}
-              <span className="ml-auto text-xs text-[var(--muted)]">{previewSegments.length} segments</span>
-            </div>
-
-            <div className="overflow-y-auto flex-1 px-5 py-3 space-y-2">
-              {previewSegments.slice(0, PREVIEW_CAP).map((text, i) => (
-                <div key={i} className="bg-[var(--surface)] rounded-xl px-4 py-3">
-                  <p className="text-sm text-[var(--foreground)] leading-relaxed">{text}</p>
-                </div>
-              ))}
-              {previewSegments.length > PREVIEW_CAP && (
-                <p className="text-center text-xs text-[var(--muted)] py-2">
-                  Showing first {PREVIEW_CAP} of {previewSegments.length} segments
-                </p>
-              )}
-            </div>
-          </div>
-        </>
-      )}
-
-      {assignTalkId && sets && (
-        <>
-          <div className="fixed inset-0 z-30 bg-black/60" onClick={() => setAssignTalkId(null)} />
-          <div className="fixed bottom-0 left-0 right-0 z-40 bg-[var(--background)] rounded-t-2xl max-h-[60dvh] flex flex-col">
-            <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-[var(--border)] shrink-0">
-              <button onClick={() => setAssignTalkId(null)} className="text-[var(--muted)] text-sm">Done</button>
-              <span className="text-sm font-semibold">Add to set</span>
-              <div className="w-12" />
-            </div>
-            <div className="overflow-y-auto flex-1 px-4 py-3 space-y-2">
-              {sets.map((set) => {
-                const inSet = set.talkIds.includes(assignTalkId as Id<'talks'>);
-                return (
-                  <button
-                    key={set._id}
-                    onClick={() => {
-                      if (!clerkId) return;
-                      if (inSet) {
-                        removeTalkFromSet({ id: set._id, userId: clerkId, talkId: assignTalkId as Id<'talks'> });
-                      } else {
-                        addTalkToSet({ id: set._id, userId: clerkId, talkId: assignTalkId as Id<'talks'> });
-                      }
-                    }}
-                    className="w-full flex items-center justify-between bg-[var(--surface)] rounded-xl px-4 py-4 text-left"
-                  >
-                    <span className="font-medium text-[var(--foreground)]">{set.title}</span>
-                    <span className={`text-lg ${inSet ? 'text-[var(--primary)]' : 'text-[var(--muted)]'}`}>
-                      {inSet ? 'OK' : '+'}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        </>
-      )}
+      <AssignTalkSheet
+        assignTalkId={assignTalkId}
+        sets={sets}
+        onClose={() => setAssignTalkId(null)}
+        onToggleSet={handleToggleSetMembership}
+      />
     </div>
   );
 }

--- a/components/library/AssignTalkSheet.tsx
+++ b/components/library/AssignTalkSheet.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Id } from '@/convex/_generated/dataModel';
+import { TalkSetDoc } from './libraryTypes';
+
+interface AssignTalkSheetProps {
+  assignTalkId: string | null;
+  sets: TalkSetDoc[] | undefined;
+  onClose: () => void;
+  onToggleSet: (setId: Id<'talkSets'>, inSet: boolean) => void;
+}
+
+export function AssignTalkSheet({
+  assignTalkId,
+  sets,
+  onClose,
+  onToggleSet,
+}: AssignTalkSheetProps) {
+  if (!assignTalkId || !sets) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-30 bg-black/60" onClick={onClose} />
+      <div className="fixed bottom-0 left-0 right-0 z-40 flex max-h-[60dvh] flex-col rounded-t-2xl bg-[var(--background)]">
+        <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-5 pb-3 pt-5">
+          <button onClick={onClose} className="text-sm text-[var(--muted)]">
+            Done
+          </button>
+          <span className="text-sm font-semibold">Add to set</span>
+          <div className="w-12" />
+        </div>
+        <div className="flex-1 space-y-2 overflow-y-auto px-4 py-3">
+          {sets.map((set) => {
+            const inSet = set.talkIds.includes(assignTalkId as Id<'talks'>);
+
+            return (
+              <button
+                key={set._id}
+                onClick={() => onToggleSet(set._id, inSet)}
+                className="flex w-full items-center justify-between rounded-xl bg-[var(--surface)] px-4 py-4 text-left"
+              >
+                <span className="font-medium text-[var(--foreground)]">{set.title}</span>
+                <span className={`text-lg ${inSet ? 'text-[var(--primary)]' : 'text-[var(--muted)]'}`}>
+                  {inSet ? 'OK' : '+'}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/library/ImportTalkSheet.tsx
+++ b/components/library/ImportTalkSheet.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { ImportDraft, SegmentMode } from './libraryTypes';
+
+const PREVIEW_CAP = 100;
+
+interface ImportTalkSheetProps {
+  importDraft: ImportDraft | null;
+  importing: boolean;
+  previewSegments: string[];
+  onClose: () => void;
+  onConfirm: () => void;
+  onModeChange: (mode: SegmentMode) => void;
+  onTitleChange: (value: string) => void;
+}
+
+export function ImportTalkSheet({
+  importDraft,
+  importing,
+  previewSegments,
+  onClose,
+  onConfirm,
+  onModeChange,
+  onTitleChange,
+}: ImportTalkSheetProps) {
+  if (!importDraft) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-30 bg-black/60" onClick={onClose} />
+      <div className="fixed bottom-0 left-0 right-0 z-40 flex max-h-[85dvh] flex-col rounded-t-2xl bg-[var(--background)]">
+        <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-5 pb-3 pt-5">
+          <button onClick={onClose} className="text-sm text-[var(--muted)]">
+            Cancel
+          </button>
+          <span className="text-sm font-semibold">Import talk</span>
+          <button
+            onClick={onConfirm}
+            disabled={importing}
+            className="text-sm font-semibold text-[var(--primary)] disabled:opacity-40"
+          >
+            {importing ? 'Saving...' : 'Import'}
+          </button>
+        </div>
+
+        <div className="shrink-0 border-b border-[var(--border)] px-5 py-3">
+          <input
+            value={importDraft.title}
+            onChange={(event) => onTitleChange(event.target.value)}
+            className="w-full bg-transparent text-base font-medium text-[var(--foreground)] outline-none placeholder-[var(--muted)]"
+            placeholder="Talk title"
+          />
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1 border-b border-[var(--border)] px-5 py-3">
+          <span className="mr-2 text-xs text-[var(--muted)]">Split by</span>
+          {(['paragraphs', 'sentences'] as SegmentMode[]).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => onModeChange(mode)}
+              className={`rounded-lg px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
+                importDraft.mode === mode
+                  ? 'bg-[var(--primary)] text-white'
+                  : 'bg-[var(--surface)] text-[var(--muted)]'
+              }`}
+            >
+              {mode}
+            </button>
+          ))}
+          <span className="ml-auto text-xs text-[var(--muted)]">
+            {previewSegments.length} segments
+          </span>
+        </div>
+
+        <div className="flex-1 space-y-2 overflow-y-auto px-5 py-3">
+          {previewSegments.slice(0, PREVIEW_CAP).map((text, index) => (
+            <div key={index} className="rounded-xl bg-[var(--surface)] px-4 py-3">
+              <p className="text-sm leading-relaxed text-[var(--foreground)]">{text}</p>
+            </div>
+          ))}
+          {previewSegments.length > PREVIEW_CAP ? (
+            <p className="py-2 text-center text-xs text-[var(--muted)]">
+              Showing first {PREVIEW_CAP} of {previewSegments.length} segments
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/library/LibraryFab.tsx
+++ b/components/library/LibraryFab.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { LibraryTab } from './libraryTypes';
+
+interface LibraryFabProps {
+  fabOpen: boolean;
+  tab: LibraryTab;
+  onOpenImport: () => void;
+  onOpenNew: () => void;
+  onToggle: () => void;
+  onClose: () => void;
+}
+
+export function LibraryFab({
+  fabOpen,
+  tab,
+  onOpenImport,
+  onOpenNew,
+  onToggle,
+  onClose,
+}: LibraryFabProps) {
+  return (
+    <>
+      {fabOpen ? <div className="fixed inset-0 z-10" onClick={onClose} /> : null}
+
+      <div className="fixed bottom-6 right-5 z-20 flex flex-col items-end gap-3">
+        {fabOpen && tab === 'talks' ? (
+          <>
+            <button
+              onClick={onOpenImport}
+              className="flex items-center gap-3 whitespace-nowrap rounded-2xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm font-medium text-[var(--foreground)] shadow-lg"
+            >
+              Import file
+              <span className="text-xs text-[var(--muted)]">.docx / .pdf</span>
+            </button>
+            <button
+              onClick={onOpenNew}
+              className="flex items-center gap-3 rounded-2xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm font-medium text-[var(--foreground)] shadow-lg"
+            >
+              New talk
+            </button>
+          </>
+        ) : null}
+        <button
+          onClick={tab === 'sets' ? onOpenNew : onToggle}
+          className={`flex h-14 w-14 items-center justify-center rounded-full bg-[var(--primary)] text-2xl text-white shadow-lg transition-transform active:scale-95 ${
+            fabOpen ? 'rotate-45' : ''
+          }`}
+        >
+          +
+        </button>
+      </div>
+    </>
+  );
+}

--- a/components/library/LibraryHeader.tsx
+++ b/components/library/LibraryHeader.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+interface LibraryHeaderProps {
+  syncClassName: string;
+  syncError: string | null;
+  syncLabel: string;
+}
+
+export function LibraryHeader({
+  syncClassName,
+  syncError,
+  syncLabel,
+}: LibraryHeaderProps) {
+  return (
+    <header className="flex items-center justify-between border-b border-[var(--border)] px-5 pb-4 pt-6">
+      <div>
+        <h1
+          className="text-2xl font-semibold tracking-tight"
+          style={{ fontFamily: 'var(--font-display)' }}
+        >
+          Podium
+        </h1>
+        <p className={`mt-1 text-xs ${syncClassName}`} title={syncError ?? undefined}>
+          {syncLabel}
+        </p>
+      </div>
+      <a href="/settings" className="text-sm text-[var(--muted)] hover:text-[var(--foreground)]">
+        Settings
+      </a>
+    </header>
+  );
+}

--- a/components/library/LibraryTabs.tsx
+++ b/components/library/LibraryTabs.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { LibraryTab } from './libraryTypes';
+
+interface LibraryTabsProps {
+  activeTab: LibraryTab;
+  onTabChange: (tab: LibraryTab) => void;
+}
+
+export function LibraryTabs({ activeTab, onTabChange }: LibraryTabsProps) {
+  return (
+    <div className="flex border-b border-[var(--border)]">
+      {(['talks', 'sets'] as LibraryTab[]).map((tab) => (
+        <button
+          key={tab}
+          onClick={() => onTabChange(tab)}
+          className={`flex-1 py-3 text-sm font-medium capitalize transition-colors ${
+            activeTab === tab
+              ? 'border-b-2 border-[var(--primary)] text-[var(--primary)]'
+              : 'text-[var(--muted)]'
+          }`}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/library/SetList.tsx
+++ b/components/library/SetList.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { FormEvent } from 'react';
+import { CreateMode, TalkSetDoc } from './libraryTypes';
+
+interface SetListProps {
+  confirmDeleteId: string | null;
+  createMode: CreateMode;
+  newSetTitle: string;
+  sets: TalkSetDoc[] | undefined;
+  onCancelCreate: () => void;
+  onCreateSet: (event: FormEvent<HTMLFormElement>) => void;
+  onDeleteCancel: () => void;
+  onDeleteConfirm: (setId: string) => void;
+  onDeleteRequest: (setId: string) => void;
+  onNewSetTitleChange: (value: string) => void;
+}
+
+export function SetList({
+  confirmDeleteId,
+  createMode,
+  newSetTitle,
+  sets,
+  onCancelCreate,
+  onCreateSet,
+  onDeleteCancel,
+  onDeleteConfirm,
+  onDeleteRequest,
+  onNewSetTitleChange,
+}: SetListProps) {
+  return (
+    <>
+      {sets === undefined ? <p className="py-8 text-center text-[var(--muted)]">Loading...</p> : null}
+
+      {sets?.length === 0 && createMode === 'none' ? (
+        <p className="py-12 text-center text-sm text-[var(--muted)]">
+          No sets yet. Group talks for an event.
+        </p>
+      ) : null}
+
+      {sets?.map((set) => (
+        <div
+          key={set._id}
+          className="rounded-xl bg-[var(--surface)] px-4 py-4 transition-colors hover:bg-[var(--surface-hover)]"
+        >
+          <div className="flex items-center justify-between">
+            <a href={`/set/${set._id}`} className="flex-1 font-medium text-[var(--foreground)]">
+              {set.title}
+            </a>
+            {confirmDeleteId === set._id ? (
+              <div className="flex shrink-0 items-center gap-2">
+                <button
+                  onClick={() => onDeleteConfirm(set._id)}
+                  className="rounded px-2 py-1 text-xs text-red-400 transition-colors"
+                >
+                  Confirm
+                </button>
+                <button
+                  onClick={onDeleteCancel}
+                  className="rounded px-2 py-1 text-xs text-[var(--muted)] transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => onDeleteRequest(set._id)}
+                className="rounded px-2 py-1 text-xs text-[var(--muted)] transition-colors hover:text-red-400"
+              >
+                Delete
+              </button>
+            )}
+          </div>
+          <p className="mt-1 text-xs text-[var(--muted)]">
+            {set.talkIds.length} {set.talkIds.length === 1 ? 'talk' : 'talks'}
+          </p>
+        </div>
+      ))}
+
+      {createMode === 'set' ? (
+        <form onSubmit={onCreateSet} className="flex gap-2">
+          <input
+            autoFocus
+            value={newSetTitle}
+            onChange={(event) => onNewSetTitleChange(event.target.value)}
+            placeholder="Set title (e.g. Conference 2026)"
+            className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--foreground)] outline-none placeholder-[var(--muted)] focus:border-[var(--primary)]"
+          />
+          <button
+            type="submit"
+            className="rounded-xl bg-[var(--primary)] px-4 py-3 text-sm font-medium text-white"
+          >
+            Add
+          </button>
+          <button
+            type="button"
+            onClick={onCancelCreate}
+            className="px-3 py-3 text-sm text-[var(--muted)]"
+          >
+            Cancel
+          </button>
+        </form>
+      ) : null}
+    </>
+  );
+}

--- a/components/library/TalkList.tsx
+++ b/components/library/TalkList.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { FormEvent } from 'react';
+import { OfflineStatusBadge } from '@/components/offline/OfflineStatusBadge';
+import { CachedTalkStatus } from '@/lib/offlineStore';
+import { CreateMode, TalkDoc } from './libraryTypes';
+
+interface TalkListProps {
+  confirmDeleteId: string | null;
+  createMode: CreateMode;
+  importError: string;
+  newTalkTitle: string;
+  setsAvailable: boolean;
+  talkStatuses: Record<string, CachedTalkStatus>;
+  talks: TalkDoc[] | undefined;
+  onAssignRequest: (talkId: string) => void;
+  onCancelCreate: () => void;
+  onCreateTalk: (event: FormEvent<HTMLFormElement>) => void;
+  onDeleteCancel: () => void;
+  onDeleteConfirm: (talkId: string) => void;
+  onDeleteRequest: (talkId: string) => void;
+  onNewTalkTitleChange: (value: string) => void;
+}
+
+export function TalkList({
+  confirmDeleteId,
+  createMode,
+  importError,
+  newTalkTitle,
+  setsAvailable,
+  talkStatuses,
+  talks,
+  onAssignRequest,
+  onCancelCreate,
+  onCreateTalk,
+  onDeleteCancel,
+  onDeleteConfirm,
+  onDeleteRequest,
+  onNewTalkTitleChange,
+}: TalkListProps) {
+  return (
+    <>
+      {talks === undefined ? (
+        <p className="py-8 text-center text-[var(--muted)]">Loading...</p>
+      ) : null}
+
+      {talks?.length === 0 && createMode === 'none' ? (
+        <p className="py-12 text-center text-sm text-[var(--muted)]">
+          No talks yet. Tap + to create your first.
+        </p>
+      ) : null}
+
+      {talks?.map((talk) => (
+        <div
+          key={talk._id}
+          className="flex items-center justify-between gap-3 rounded-xl bg-[var(--surface)] px-4 py-4 transition-colors hover:bg-[var(--surface-hover)]"
+        >
+          <div className="min-w-0 flex-1">
+            <a href={`/talk/${talk._id}`} className="block truncate font-medium text-[var(--foreground)]">
+              {talk.title}
+            </a>
+            <div className="mt-2">
+              <OfflineStatusBadge status={talkStatuses[talk._id]} documentAvailable />
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {setsAvailable ? (
+              <button
+                onClick={() => onAssignRequest(talk._id)}
+                className="rounded px-2 py-1 text-lg leading-none text-[var(--muted)] transition-colors hover:text-[var(--primary)]"
+                title="Add to set"
+              >
+                +
+              </button>
+            ) : null}
+            {confirmDeleteId === talk._id ? (
+              <>
+                <button
+                  onClick={() => onDeleteConfirm(talk._id)}
+                  className="rounded px-2 py-1 text-xs text-red-400 transition-colors"
+                >
+                  Confirm
+                </button>
+                <button
+                  onClick={onDeleteCancel}
+                  className="rounded px-2 py-1 text-xs text-[var(--muted)] transition-colors"
+                >
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={() => onDeleteRequest(talk._id)}
+                className="rounded px-2 py-1 text-xs text-[var(--muted)] transition-colors hover:text-red-400"
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+
+      {createMode === 'new' ? (
+        <form onSubmit={onCreateTalk} className="flex gap-2">
+          <input
+            autoFocus
+            value={newTalkTitle}
+            onChange={(event) => onNewTalkTitleChange(event.target.value)}
+            placeholder="Talk title"
+            className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--foreground)] outline-none placeholder-[var(--muted)] focus:border-[var(--primary)]"
+          />
+          <button
+            type="submit"
+            className="rounded-xl bg-[var(--primary)] px-4 py-3 text-sm font-medium text-white"
+          >
+            Add
+          </button>
+          <button
+            type="button"
+            onClick={onCancelCreate}
+            className="px-3 py-3 text-sm text-[var(--muted)]"
+          >
+            Cancel
+          </button>
+        </form>
+      ) : null}
+
+      {importError ? <p className="py-2 text-center text-sm text-red-400">{importError}</p> : null}
+    </>
+  );
+}

--- a/components/library/libraryTypes.ts
+++ b/components/library/libraryTypes.ts
@@ -1,0 +1,15 @@
+import { Doc } from '@/convex/_generated/dataModel';
+
+export type LibraryTab = 'talks' | 'sets';
+export type CreateMode = 'none' | 'new' | 'set';
+export type SegmentMode = 'paragraphs' | 'sentences';
+
+export interface ImportDraft {
+  title: string;
+  fullText: string;
+  paragraphs: string[];
+  mode: SegmentMode;
+}
+
+export type TalkDoc = Doc<'talks'>;
+export type TalkSetDoc = Doc<'talkSets'>;


### PR DESCRIPTION
## Summary
- split the online library page into focused header, tab, list, fab, and sheet components
- keep Convex queries, mutations, and offline sync orchestration in the route component
- centralize the library UI prop shapes in shared library component types

## Testing
- npm run build
- npm run lint

Closes #78