### PR TITLE
Split settings page and fix text encoding artifacts

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useQuery, useMutation } from 'convex/react';
-import { api } from '@/convex/_generated/api';
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { AzureSection } from '@/components/settings/AzureSection';
+import { ElevenLabsSection } from '@/components/settings/ElevenLabsSection';
+import { ProviderToggle } from '@/components/settings/ProviderToggle';
+import { VoicePicker } from '@/components/settings/VoicePicker';
 import { OfflineGate } from '@/components/offline/OfflineGate';
+import { api } from '@/convex/_generated/api';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
-import { fetchVoices, TTSConfig, TTSVoice, DEFAULT_VOICE_ID } from '@/lib/tts';
+import { DEFAULT_VOICE_ID, fetchVoices, TTSConfig, TTSVoice } from '@/lib/tts';
 
-const MASKED = '••••••••••••••••';
+const MASKED = '****************';
 
 export default function SettingsPage() {
   return (
@@ -33,18 +37,15 @@ function OnlineSettingsPage() {
   const provider = settings?.provider ?? 'elevenlabs';
   const isAzure = provider === 'azure';
 
-  // ElevenLabs key state
   const [elKeyInput, setElKeyInput] = useState('');
   const [elMasked, setElMasked] = useState(false);
   const [elSaved, setElSaved] = useState(false);
 
-  // Azure credentials state
   const [azKeyInput, setAzKeyInput] = useState('');
   const [azKeyMasked, setAzKeyMasked] = useState(false);
   const [azRegionInput, setAzRegionInput] = useState('');
   const [azSaved, setAzSaved] = useState(false);
 
-  // Voice state
   const [voices, setVoices] = useState<TTSVoice[]>([]);
   const [voicesLoading, setVoicesLoading] = useState(false);
   const [voicesError, setVoicesError] = useState(false);
@@ -54,9 +55,10 @@ function OnlineSettingsPage() {
     if (settings?.elevenLabsApiKey) {
       setElKeyInput('');
       setElMasked(true);
-    } else {
-      setElMasked(false);
+      return;
     }
+
+    setElMasked(false);
   }, [settings?.elevenLabsApiKey]);
 
   useEffect(() => {
@@ -66,6 +68,7 @@ function OnlineSettingsPage() {
     } else {
       setAzKeyMasked(false);
     }
+
     if (settings?.azureRegion) {
       setAzRegionInput(settings.azureRegion);
     }
@@ -74,31 +77,45 @@ function OnlineSettingsPage() {
   const ttsConfig: TTSConfig | null = settings
     ? isAzure
       ? settings.azureSubscriptionKey && settings.azureRegion
-        ? { provider: 'azure', subscriptionKey: settings.azureSubscriptionKey, region: settings.azureRegion, voiceId: settings.voiceId }
+        ? {
+            provider: 'azure',
+            subscriptionKey: settings.azureSubscriptionKey,
+            region: settings.azureRegion,
+            voiceId: settings.voiceId,
+          }
         : null
       : settings.elevenLabsApiKey
-        ? { provider: 'elevenlabs', apiKey: settings.elevenLabsApiKey, voiceId: settings.voiceId }
+        ? {
+            provider: 'elevenlabs',
+            apiKey: settings.elevenLabsApiKey,
+            voiceId: settings.voiceId,
+          }
         : null
     : null;
 
   useEffect(() => {
-    if (!ttsConfig) { setVoices([]); return; }
+    if (!ttsConfig) {
+      setVoices([]);
+      return;
+    }
+
     setVoicesLoading(true);
     setVoicesError(false);
     fetchVoices(ttsConfig)
-      .then((v) => setVoices(v))
+      .then((availableVoices) => setVoices(availableVoices))
       .catch(() => setVoicesError(true))
       .finally(() => setVoicesLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings?.elevenLabsApiKey, settings?.azureSubscriptionKey, settings?.azureRegion, provider]);
 
   function handlePreview(voice: TTSVoice) {
     if (!voice.previewUrl) return;
+
     previewAudio?.pause();
     const audio = new Audio(voice.previewUrl);
     setPreviewAudio(audio);
     audio.onended = () => setPreviewAudio(null);
-    audio.play();
+    void audio.play();
   }
 
   async function handleSelectVoice(voiceId: string) {
@@ -106,14 +123,15 @@ function OnlineSettingsPage() {
     await saveVoiceId({ clerkId, voiceId });
   }
 
-  async function handleProviderChange(p: 'elevenlabs' | 'azure') {
+  async function handleProviderChange(nextProvider: 'elevenlabs' | 'azure') {
     if (!clerkId) return;
-    await saveProvider({ clerkId, provider: p });
+    await saveProvider({ clerkId, provider: nextProvider });
   }
 
-  async function handleElSave(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleElSave(event: React.FormEvent) {
+    event.preventDefault();
     if (!clerkId || !elKeyInput.trim()) return;
+
     await saveApiKey({ clerkId, elevenLabsApiKey: elKeyInput.trim() });
     setElKeyInput('');
     setElMasked(true);
@@ -123,22 +141,33 @@ function OnlineSettingsPage() {
 
   async function handleElClear() {
     if (!clerkId) return;
+
     await clearApiKey({ clerkId });
     setElKeyInput('');
     setElMasked(false);
   }
 
-  async function handleAzSave(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleAzSave(event: React.FormEvent) {
+    event.preventDefault();
     if (!clerkId || !azRegionInput.trim()) return;
-    const key = azKeyMasked ? undefined : azKeyInput.trim();
-    if (!azKeyMasked && !key) return;
-    if (key) {
-      await saveAzureCredentials({ clerkId, azureSubscriptionKey: key, azureRegion: azRegionInput.trim() });
-    } else {
-      // Only region changed — patch region via saveAzureCredentials with existing key
-      await saveAzureCredentials({ clerkId, azureSubscriptionKey: settings!.azureSubscriptionKey!, azureRegion: azRegionInput.trim() });
+
+    const nextKey = azKeyMasked ? undefined : azKeyInput.trim();
+    if (!azKeyMasked && !nextKey) return;
+
+    if (nextKey) {
+      await saveAzureCredentials({
+        clerkId,
+        azureSubscriptionKey: nextKey,
+        azureRegion: azRegionInput.trim(),
+      });
+    } else if (settings?.azureSubscriptionKey) {
+      await saveAzureCredentials({
+        clerkId,
+        azureSubscriptionKey: settings.azureSubscriptionKey,
+        azureRegion: azRegionInput.trim(),
+      });
     }
+
     setAzKeyInput('');
     setAzKeyMasked(true);
     setAzSaved(true);
@@ -147,6 +176,7 @@ function OnlineSettingsPage() {
 
   async function handleAzClear() {
     if (!clerkId) return;
+
     await clearAzureCredentials({ clerkId });
     setAzKeyInput('');
     setAzKeyMasked(false);
@@ -158,179 +188,69 @@ function OnlineSettingsPage() {
     : !!settings?.elevenLabsApiKey;
 
   const selectedVoiceId = settings?.voiceId ?? DEFAULT_VOICE_ID;
-  const selectedVoice = voices.find((v) => v.id === selectedVoiceId);
+  const selectedVoice = voices.find((voice) => voice.id === selectedVoiceId);
 
   return (
-    <div className="flex flex-col min-h-dvh bg-[var(--background)] text-[var(--foreground)]">
-      <header className="flex items-center gap-3 px-5 pt-6 pb-4 border-b border-[var(--border)]">
-        <a href="/library" className="text-[var(--muted)] hover:text-[var(--foreground)] text-sm">
-          ← Library
+    <div className="flex min-h-dvh flex-col bg-[var(--background)] text-[var(--foreground)]">
+      <header className="flex items-center gap-3 border-b border-[var(--border)] px-5 pb-4 pt-6">
+        <a href="/library" className="text-sm text-[var(--muted)] hover:text-[var(--foreground)]">
+          &lt;- Library
         </a>
         <h1 className="text-lg font-semibold">Settings</h1>
       </header>
 
-      <main className="flex-1 px-5 py-6 space-y-8 max-w-lg">
+      <main className="max-w-lg flex-1 space-y-8 px-5 py-6">
+        <ProviderToggle isAzure={isAzure} onProviderChange={handleProviderChange} />
 
-        {/* Provider toggle */}
-        <section>
-          <h2 className="text-sm font-semibold text-[var(--muted)] uppercase tracking-wider mb-3">
-            TTS Provider
-          </h2>
-          <div className="flex rounded-xl overflow-hidden border border-[var(--border)]">
-            <button
-              onClick={() => handleProviderChange('elevenlabs')}
-              className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
-                !isAzure
-                  ? 'bg-[var(--primary)] text-white'
-                  : 'bg-[var(--surface)] text-[var(--muted)]'
-              }`}
-            >
-              ElevenLabs
-            </button>
-            <button
-              onClick={() => handleProviderChange('azure')}
-              className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
-                isAzure
-                  ? 'bg-[var(--primary)] text-white'
-                  : 'bg-[var(--surface)] text-[var(--muted)]'
-              }`}
-            >
-              Azure
-            </button>
-          </div>
-        </section>
-
-        {/* ElevenLabs credentials */}
-        {!isAzure && (
-          <section>
-            <h2 className="text-sm font-semibold text-[var(--muted)] uppercase tracking-wider mb-3">
-              ElevenLabs API Key
-            </h2>
-            <p className="text-sm text-[var(--muted)] mb-4">
-              Your key is stored securely and never shared.
-            </p>
-            <form onSubmit={handleElSave} className="space-y-3">
-              <input
-                type={elMasked ? 'text' : 'password'}
-                value={elMasked ? MASKED : elKeyInput}
-                onChange={(e) => { if (!elMasked) setElKeyInput(e.target.value); }}
-                onFocus={() => { if (elMasked) { setElMasked(false); setElKeyInput(''); } }}
-                placeholder="sk_..."
-                className="w-full bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] placeholder-[var(--muted)] outline-none border border-[var(--border)] focus:border-[var(--primary)] font-mono"
-              />
-              {elMasked && (
-                <p className="text-xs text-[var(--muted)]">Key saved. Tap the field to replace it.</p>
-              )}
-              <div className="flex gap-2">
-                <button
-                  type="submit"
-                  disabled={elMasked || !elKeyInput.trim()}
-                  className="flex-1 bg-[var(--primary)] text-white rounded-xl py-3 text-sm font-medium disabled:opacity-40 transition-opacity"
-                >
-                  {elSaved ? 'Saved!' : 'Save key'}
-                </button>
-                {settings?.elevenLabsApiKey && (
-                  <button
-                    type="button"
-                    onClick={handleElClear}
-                    className="px-4 py-3 text-sm text-red-400 hover:text-red-300 transition-colors"
-                  >
-                    Remove
-                  </button>
-                )}
-              </div>
-            </form>
-          </section>
+        {!isAzure ? (
+          <ElevenLabsSection
+            hasSavedKey={!!settings?.elevenLabsApiKey}
+            keyInput={elKeyInput}
+            masked={elMasked}
+            maskedValue={MASKED}
+            saved={elSaved}
+            onChange={setElKeyInput}
+            onClear={handleElClear}
+            onFocus={() => {
+              if (elMasked) {
+                setElMasked(false);
+                setElKeyInput('');
+              }
+            }}
+            onSubmit={handleElSave}
+          />
+        ) : (
+          <AzureSection
+            hasSavedKey={!!settings?.azureSubscriptionKey}
+            keyInput={azKeyInput}
+            keyMasked={azKeyMasked}
+            maskedValue={MASKED}
+            regionInput={azRegionInput}
+            saved={azSaved}
+            onClear={handleAzClear}
+            onKeyChange={setAzKeyInput}
+            onKeyFocus={() => {
+              if (azKeyMasked) {
+                setAzKeyMasked(false);
+                setAzKeyInput('');
+              }
+            }}
+            onRegionChange={setAzRegionInput}
+            onSubmit={handleAzSave}
+          />
         )}
 
-        {/* Azure credentials */}
-        {isAzure && (
-          <section>
-            <h2 className="text-sm font-semibold text-[var(--muted)] uppercase tracking-wider mb-3">
-              Azure Credentials
-            </h2>
-            <p className="text-sm text-[var(--muted)] mb-4">
-              Your subscription key and region are stored securely and never shared.
-            </p>
-            <form onSubmit={handleAzSave} className="space-y-3">
-              <input
-                type={azKeyMasked ? 'text' : 'password'}
-                value={azKeyMasked ? MASKED : azKeyInput}
-                onChange={(e) => { if (!azKeyMasked) setAzKeyInput(e.target.value); }}
-                onFocus={() => { if (azKeyMasked) { setAzKeyMasked(false); setAzKeyInput(''); } }}
-                placeholder="Subscription key"
-                className="w-full bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] placeholder-[var(--muted)] outline-none border border-[var(--border)] focus:border-[var(--primary)] font-mono"
-              />
-              <input
-                type="text"
-                value={azRegionInput}
-                onChange={(e) => setAzRegionInput(e.target.value)}
-                placeholder="Region (e.g. eastus)"
-                className="w-full bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] placeholder-[var(--muted)] outline-none border border-[var(--border)] focus:border-[var(--primary)] font-mono"
-              />
-              {azKeyMasked && (
-                <p className="text-xs text-[var(--muted)]">Key saved. Tap the field to replace it.</p>
-              )}
-              <div className="flex gap-2">
-                <button
-                  type="submit"
-                  disabled={(!azKeyMasked && !azKeyInput.trim()) || !azRegionInput.trim()}
-                  className="flex-1 bg-[var(--primary)] text-white rounded-xl py-3 text-sm font-medium disabled:opacity-40 transition-opacity"
-                >
-                  {azSaved ? 'Saved!' : 'Save'}
-                </button>
-                {settings?.azureSubscriptionKey && (
-                  <button
-                    type="button"
-                    onClick={handleAzClear}
-                    className="px-4 py-3 text-sm text-red-400 hover:text-red-300 transition-colors"
-                  >
-                    Remove
-                  </button>
-                )}
-              </div>
-            </form>
-          </section>
-        )}
-
-        {/* Voice picker */}
-        {hasCredentials && (
-          <section>
-            <h2 className="text-sm font-semibold text-[var(--muted)] uppercase tracking-wider mb-3">
-              Voice
-            </h2>
-            {voicesLoading && (
-              <p className="text-sm text-[var(--muted)]">Loading voices…</p>
-            )}
-            {voicesError && (
-              <p className="text-sm text-red-400">Failed to load voices.</p>
-            )}
-            {!voicesLoading && !voicesError && voices.length > 0 && (
-              <div className="flex items-center gap-2">
-                <select
-                  value={selectedVoiceId}
-                  onChange={(e) => handleSelectVoice(e.target.value)}
-                  className="flex-1 bg-[var(--surface)] rounded-xl px-4 py-3 text-sm text-[var(--foreground)] outline-none border border-[var(--border)] focus:border-[var(--primary)]"
-                >
-                  {voices.map((voice) => (
-                    <option key={voice.id} value={voice.id}>
-                      {voice.name}
-                    </option>
-                  ))}
-                </select>
-                {selectedVoice?.previewUrl && (
-                  <button
-                    type="button"
-                    onClick={() => selectedVoice && handlePreview(selectedVoice)}
-                    className="px-4 py-3 rounded-xl bg-[var(--surface)] border border-[var(--border)] text-sm text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
-                  >
-                    ▶
-                  </button>
-                )}
-              </div>
-            )}
-          </section>
-        )}
+        {hasCredentials ? (
+          <VoicePicker
+            selectedVoice={selectedVoice}
+            selectedVoiceId={selectedVoiceId}
+            voices={voices}
+            voicesError={voicesError}
+            voicesLoading={voicesLoading}
+            onPreview={handlePreview}
+            onSelectVoice={handleSelectVoice}
+          />
+        ) : null}
       </main>
     </div>
   );

--- a/components/settings/AzureSection.tsx
+++ b/components/settings/AzureSection.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { FormEvent } from 'react';
+
+interface AzureSectionProps {
+  hasSavedKey: boolean;
+  keyInput: string;
+  keyMasked: boolean;
+  maskedValue: string;
+  regionInput: string;
+  saved: boolean;
+  onClear: () => void;
+  onKeyChange: (value: string) => void;
+  onKeyFocus: () => void;
+  onRegionChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+export function AzureSection({
+  hasSavedKey,
+  keyInput,
+  keyMasked,
+  maskedValue,
+  regionInput,
+  saved,
+  onClear,
+  onKeyChange,
+  onKeyFocus,
+  onRegionChange,
+  onSubmit,
+}: AzureSectionProps) {
+  return (
+    <section>
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--muted)]">
+        Azure Credentials
+      </h2>
+      <p className="mb-4 text-sm text-[var(--muted)]">
+        Your subscription key and region are stored securely and never shared.
+      </p>
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          type={keyMasked ? 'text' : 'password'}
+          value={keyMasked ? maskedValue : keyInput}
+          onChange={(event) => {
+            if (!keyMasked) onKeyChange(event.target.value);
+          }}
+          onFocus={onKeyFocus}
+          placeholder="Subscription key"
+          className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 font-mono text-sm text-[var(--foreground)] outline-none placeholder-[var(--muted)] focus:border-[var(--primary)]"
+        />
+        <input
+          type="text"
+          value={regionInput}
+          onChange={(event) => onRegionChange(event.target.value)}
+          placeholder="Region (e.g. eastus)"
+          className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 font-mono text-sm text-[var(--foreground)] outline-none placeholder-[var(--muted)] focus:border-[var(--primary)]"
+        />
+        {keyMasked ? (
+          <p className="text-xs text-[var(--muted)]">Key saved. Tap the field to replace it.</p>
+        ) : null}
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            disabled={(!keyMasked && !keyInput.trim()) || !regionInput.trim()}
+            className="flex-1 rounded-xl bg-[var(--primary)] py-3 text-sm font-medium text-white transition-opacity disabled:opacity-40"
+          >
+            {saved ? 'Saved!' : 'Save'}
+          </button>
+          {hasSavedKey ? (
+            <button
+              type="button"
+              onClick={onClear}
+              className="px-4 py-3 text-sm text-red-400 transition-colors hover:text-red-300"
+            >
+              Remove
+            </button>
+          ) : null}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/components/settings/ElevenLabsSection.tsx
+++ b/components/settings/ElevenLabsSection.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { FormEvent } from 'react';
+
+interface ElevenLabsSectionProps {
+  hasSavedKey: boolean;
+  keyInput: string;
+  masked: boolean;
+  maskedValue: string;
+  saved: boolean;
+  onChange: (value: string) => void;
+  onClear: () => void;
+  onFocus: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+export function ElevenLabsSection({
+  hasSavedKey,
+  keyInput,
+  masked,
+  maskedValue,
+  saved,
+  onChange,
+  onClear,
+  onFocus,
+  onSubmit,
+}: ElevenLabsSectionProps) {
+  return (
+    <section>
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--muted)]">
+        ElevenLabs API Key
+      </h2>
+      <p className="mb-4 text-sm text-[var(--muted)]">
+        Your key is stored securely and never shared.
+      </p>
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          type={masked ? 'text' : 'password'}
+          value={masked ? maskedValue : keyInput}
+          onChange={(event) => {
+            if (!masked) onChange(event.target.value);
+          }}
+          onFocus={onFocus}
+          placeholder="sk_..."
+          className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 font-mono text-sm text-[var(--foreground)] outline-none placeholder-[var(--muted)] focus:border-[var(--primary)]"
+        />
+        {masked ? (
+          <p className="text-xs text-[var(--muted)]">Key saved. Tap the field to replace it.</p>
+        ) : null}
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            disabled={masked || !keyInput.trim()}
+            className="flex-1 rounded-xl bg-[var(--primary)] py-3 text-sm font-medium text-white transition-opacity disabled:opacity-40"
+          >
+            {saved ? 'Saved!' : 'Save key'}
+          </button>
+          {hasSavedKey ? (
+            <button
+              type="button"
+              onClick={onClear}
+              className="px-4 py-3 text-sm text-red-400 transition-colors hover:text-red-300"
+            >
+              Remove
+            </button>
+          ) : null}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/components/settings/ProviderToggle.tsx
+++ b/components/settings/ProviderToggle.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+interface ProviderToggleProps {
+  isAzure: boolean;
+  onProviderChange: (provider: 'elevenlabs' | 'azure') => void;
+}
+
+export function ProviderToggle({ isAzure, onProviderChange }: ProviderToggleProps) {
+  return (
+    <section>
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--muted)]">
+        TTS Provider
+      </h2>
+      <div className="flex overflow-hidden rounded-xl border border-[var(--border)]">
+        <button
+          onClick={() => onProviderChange('elevenlabs')}
+          className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+            !isAzure
+              ? 'bg-[var(--primary)] text-white'
+              : 'bg-[var(--surface)] text-[var(--muted)]'
+          }`}
+        >
+          ElevenLabs
+        </button>
+        <button
+          onClick={() => onProviderChange('azure')}
+          className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+            isAzure
+              ? 'bg-[var(--primary)] text-white'
+              : 'bg-[var(--surface)] text-[var(--muted)]'
+          }`}
+        >
+          Azure
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/components/settings/VoicePicker.tsx
+++ b/components/settings/VoicePicker.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { TTSVoice } from '@/lib/tts';
+
+interface VoicePickerProps {
+  selectedVoice: TTSVoice | undefined;
+  selectedVoiceId: string;
+  voices: TTSVoice[];
+  voicesError: boolean;
+  voicesLoading: boolean;
+  onPreview: (voice: TTSVoice) => void;
+  onSelectVoice: (voiceId: string) => void;
+}
+
+export function VoicePicker({
+  selectedVoice,
+  selectedVoiceId,
+  voices,
+  voicesError,
+  voicesLoading,
+  onPreview,
+  onSelectVoice,
+}: VoicePickerProps) {
+  return (
+    <section>
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--muted)]">
+        Voice
+      </h2>
+      {voicesLoading ? <p className="text-sm text-[var(--muted)]">Loading voices...</p> : null}
+      {voicesError ? <p className="text-sm text-red-400">Failed to load voices.</p> : null}
+      {!voicesLoading && !voicesError && voices.length > 0 ? (
+        <div className="flex items-center gap-2">
+          <select
+            value={selectedVoiceId}
+            onChange={(event) => onSelectVoice(event.target.value)}
+            className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--foreground)] outline-none focus:border-[var(--primary)]"
+          >
+            {voices.map((voice) => (
+              <option key={voice.id} value={voice.id}>
+                {voice.name}
+              </option>
+            ))}
+          </select>
+          {selectedVoice?.previewUrl ? (
+            <button
+              type="button"
+              onClick={() => onPreview(selectedVoice)}
+              className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)]"
+            >
+              Preview
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- split the settings page into focused provider, credential, and voice-picker components
- keep the page component focused on data loading and mutation orchestration
- normalize the visible mojibake strings in settings to plain ASCII labels

## Testing
- npm run build
- npm run lint

Closes #79