### PR TITLE
fix: re-download audio on voice change or SSML update (#112)

### DIFF
--- a/app/talk/[id]/OnlineTalkPage.tsx
+++ b/app/talk/[id]/OnlineTalkPage.tsx
@@ -8,7 +8,7 @@ import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
 import { useOfflineBoot } from '@/hooks/useOfflineBoot';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
-import { getCachedAudio, saveTalkData, setCachedAudio } from '@/lib/audioStore';
+import { clearTalkAudio, getCachedAudio, getTalkData, saveTalkData, setCachedAudio } from '@/lib/audioStore';
 import { getTalkPreparedState, saveTalkPreparedState } from '@/lib/offlineStore';
 import { buildSSML, SegmentElement } from '@/lib/ssml';
 import { fetchTTSBlob, TTSConfig } from '@/lib/tts';
@@ -113,6 +113,13 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
     const currentAudioUrls = audioUrls.current;
 
     async function prepare() {
+      // Clear stale audio if the voice has changed since the last download
+      const storedTalk = await getTalkData(id);
+      if (storedTalk?.voiceKey && storedTalk.voiceKey !== voiceKey) {
+        await clearTalkAudio(id);
+      }
+      if (signal.aborted) return;
+
       const idbResults = await Promise.all(
         segments.map(async (segment, segmentIndex) => {
           const cacheKey = segment.elements
@@ -193,6 +200,21 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
       currentAudioUrls.clear();
     };
   }, [clerkId, id, isAzure, segments, ttsConfig, voiceKey]);
+
+  // Stable identity string that changes when segment content or voice changes
+  const audioIdentityKey = voiceKey + segments.map(s =>
+    s.elements ? `ssml:${JSON.stringify(s.elements)}` : s.text
+  ).join('|');
+
+  // Reset cache state whenever the audio identity changes (voice or SSML update)
+  useEffect(() => {
+    setCacheReady(false);
+    setCacheChecked(false);
+    setCacheLoaded(0);
+    setCacheFailed(false);
+    setWaitingForSegment(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [audioIdentityKey]);
 
   const earlyStartReady =
     cacheChecked &&


### PR DESCRIPTION
## Problem

**Voice change:** old audio blobs (under old voiceKey) stay in IDB forever; cache state isn't reset so the talk page doesn't re-download.

**SSML update:** `invalidateTalkOfflineState` clears IDB correctly but cache state variables on the talk page don't reset, so a re-download may not be triggered.

## Fix

- `audioIdentityKey` — a string derived from `voiceKey` + each segment's content (text or JSON of elements). Changes when either the voice or any segment's SSML changes.
- `useEffect([audioIdentityKey])` resets `cacheReady / cacheChecked / cacheLoaded / cacheFailed / waitingForSegment` → talk page shows download screen again
- `prepare()` reads stored `voiceKey` from IDB at the start; if it differs from the current one, calls `clearTalkAudio(id)` to evict stale blobs before downloading under the new keys

## Test plan

- [ ] Change voice in Settings → open a talk → download screen appears, fresh audio fetched for new voice, old voice blobs evicted
- [ ] Edit a segment's SSML → navigate to talk → download screen re-appears, updated audio fetched
- [ ] No regression on normal first-load flow

Closes #112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio cache on talk pages now properly updates and clears when switching between voice options or content changes, preventing stale cached audio playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->