### PR TITLE
chore: update js-tts-wrapper to 0.1.75

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "diff": "^8.0.4",
         "framer-motion": "^12.38.0",
         "idb-keyval": "^6.2.2",
-        "js-tts-wrapper": "^0.1.72",
+        "js-tts-wrapper": "^0.1.75",
         "lucide-react": "^1.8.0",
         "mammoth": "^1.12.0",
         "next": "16.2.2",
@@ -5572,9 +5572,9 @@
       "license": "MIT"
     },
     "node_modules/js-tts-wrapper": {
-      "version": "0.1.72",
-      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.72.tgz",
-      "integrity": "sha512-4TPahVO7kqL+NPlNWKBxZwjTx84oGlSZqL5qgwPy23YOfyYNyQM4kWD8hfnethBPhZFKpI4C5L7GKZaqJdv55A==",
+      "version": "0.1.75",
+      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.75.tgz",
+      "integrity": "sha512-lDCyo6nyW5+cHhVIQf6c6hmTugYu6/d3sOtqBZmnWdtZMSsRaQG4HkqfRHGnEEHovac49p/yW1ggd+MweDZccQ==",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.32.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "diff": "^8.0.4",
     "framer-motion": "^12.38.0",
     "idb-keyval": "^6.2.2",
-    "js-tts-wrapper": "^0.1.72",
+    "js-tts-wrapper": "^0.1.75",
     "lucide-react": "^1.8.0",
     "mammoth": "^1.12.0",
     "next": "16.2.2",


### PR DESCRIPTION
## Summary

- Updates `js-tts-wrapper` from `^0.1.72` to `^0.1.75`

## Test plan

- [x] Build passes
- [ ] Test TTS functionality in the talk presenter

Closes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `js-tts-wrapper` dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->