### PR TITLE
feat: filter voices by gender and language in VoicePicker

### DIFF
--- a/components/settings/VoicePicker.tsx
+++ b/components/settings/VoicePicker.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { VoiceUtils, type UnifiedVoice } from 'js-tts-wrapper/browser';
 import { TTSVoice } from '@/lib/tts';
+
+// TTSVoice is structurally compatible with UnifiedVoice for filtering purposes
+type AsUnified = UnifiedVoice[];
 
 type GenderFilter = 'All' | 'Male' | 'Female' | 'Unknown';
 
@@ -30,27 +34,28 @@ export function VoicePicker({
   const [genderFilter, setGenderFilter] = useState<GenderFilter>('All');
   const [langFilter, setLangFilter] = useState<string>('All');
 
+  const u = voices as unknown as AsUnified;
+
   const languageOptions = useMemo(() => {
+    const bcp47Codes = VoiceUtils.getAvailableLanguages(u);
     const seen = new Map<string, string>();
-    for (const voice of voices) {
-      for (const lc of voice.languageCodes) {
-        if (!seen.has(lc.bcp47)) seen.set(lc.bcp47, lc.display);
-      }
+    for (const code of bcp47Codes) {
+      const label = voices
+        .flatMap((v) => v.languageCodes)
+        .find((lc) => lc.bcp47 === code)?.display;
+      seen.set(code, label || code);
     }
     return Array.from(seen.entries())
       .map(([bcp47, display]) => ({ bcp47, display }))
       .sort((a, b) => a.display.localeCompare(b.display));
-  }, [voices]);
+  }, [u, voices]);
 
-  const filteredVoices = useMemo(
-    () =>
-      voices.filter(
-        (v) =>
-          (genderFilter === 'All' || v.gender === genderFilter) &&
-          (langFilter === 'All' || v.languageCodes.some((lc) => lc.bcp47 === langFilter)),
-      ),
-    [voices, genderFilter, langFilter],
-  );
+  const filteredVoices = useMemo(() => {
+    let result = u;
+    if (genderFilter !== 'All') result = VoiceUtils.filterByGender(result, genderFilter);
+    if (langFilter !== 'All') result = VoiceUtils.filterByLanguage(result, langFilter);
+    return result as unknown as TTSVoice[];
+  }, [u, genderFilter, langFilter]);
 
   return (
     <section>

--- a/components/settings/VoicePicker.tsx
+++ b/components/settings/VoicePicker.tsx
@@ -1,6 +1,12 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import { TTSVoice } from '@/lib/tts';
+
+type GenderFilter = 'All' | 'Male' | 'Female' | 'Unknown';
+
+const selectClass =
+  'rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--foreground)] outline-none focus:border-[var(--primary)]';
 
 interface VoicePickerProps {
   selectedVoice: TTSVoice | undefined;
@@ -21,6 +27,31 @@ export function VoicePicker({
   onPreview,
   onSelectVoice,
 }: VoicePickerProps) {
+  const [genderFilter, setGenderFilter] = useState<GenderFilter>('All');
+  const [langFilter, setLangFilter] = useState<string>('All');
+
+  const languageOptions = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const voice of voices) {
+      for (const lc of voice.languageCodes) {
+        if (!seen.has(lc.bcp47)) seen.set(lc.bcp47, lc.display);
+      }
+    }
+    return Array.from(seen.entries())
+      .map(([bcp47, display]) => ({ bcp47, display }))
+      .sort((a, b) => a.display.localeCompare(b.display));
+  }, [voices]);
+
+  const filteredVoices = useMemo(
+    () =>
+      voices.filter(
+        (v) =>
+          (genderFilter === 'All' || v.gender === genderFilter) &&
+          (langFilter === 'All' || v.languageCodes.some((lc) => lc.bcp47 === langFilter)),
+      ),
+    [voices, genderFilter, langFilter],
+  );
+
   return (
     <section>
       <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-[var(--muted)]">
@@ -29,27 +60,62 @@ export function VoicePicker({
       {voicesLoading ? <p className="text-sm text-[var(--muted)]">Loading voices...</p> : null}
       {voicesError ? <p className="text-sm text-red-400">Failed to load voices.</p> : null}
       {!voicesLoading && !voicesError && voices.length > 0 ? (
-        <div className="flex items-center gap-2">
-          <select
-            value={selectedVoiceId}
-            onChange={(event) => onSelectVoice(event.target.value)}
-            className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--foreground)] outline-none focus:border-[var(--primary)]"
-          >
-            {voices.map((voice) => (
-              <option key={voice.id} value={voice.id}>
-                {voice.name}
-              </option>
-            ))}
-          </select>
-          {selectedVoice?.previewUrl ? (
-            <button
-              type="button"
-              onClick={() => onPreview(selectedVoice)}
-              className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)]"
+        <div className="flex flex-col gap-2">
+          <div className="grid grid-cols-2 gap-2">
+            <select
+              value={genderFilter}
+              onChange={(e) => setGenderFilter(e.target.value as GenderFilter)}
+              aria-label="Filter by gender"
+              className={selectClass}
             >
-              Preview
-            </button>
-          ) : null}
+              <option value="All">All genders</option>
+              <option value="Female">Female</option>
+              <option value="Male">Male</option>
+              <option value="Unknown">Unknown</option>
+            </select>
+            <select
+              value={langFilter}
+              onChange={(e) => setLangFilter(e.target.value)}
+              aria-label="Filter by language"
+              className={selectClass}
+            >
+              <option value="All">All languages</option>
+              {languageOptions.map((o) => (
+                <option key={o.bcp47} value={o.bcp47}>
+                  {o.display || o.bcp47}
+                </option>
+              ))}
+            </select>
+          </div>
+          <p className="text-xs text-[var(--muted)]">
+            {filteredVoices.length} of {voices.length} voices
+          </p>
+          {filteredVoices.length === 0 ? (
+            <p className="text-sm text-[var(--muted)]">No voices match the selected filters.</p>
+          ) : (
+            <div className="flex items-center gap-2">
+              <select
+                value={selectedVoiceId}
+                onChange={(event) => onSelectVoice(event.target.value)}
+                className={`flex-1 ${selectClass}`}
+              >
+                {filteredVoices.map((voice) => (
+                  <option key={voice.id} value={voice.id}>
+                    {voice.name}
+                  </option>
+                ))}
+              </select>
+              {selectedVoice?.previewUrl ? (
+                <button
+                  type="button"
+                  onClick={() => onPreview(selectedVoice)}
+                  className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)]"
+                >
+                  Preview
+                </button>
+              ) : null}
+            </div>
+          )}
         </div>
       ) : null}
     </section>

--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -14,6 +14,7 @@ export interface TTSVoice {
   previewUrl?: string;
   gender?: 'Male' | 'Female' | 'Unknown';
   languageCodes: { bcp47: string; iso639_3: string; display: string }[];
+  provider: string;
 }
 
 function createClient(config: TTSConfig) {
@@ -42,6 +43,7 @@ export async function fetchVoices(config: TTSConfig): Promise<TTSVoice[]> {
       name: v.name,
       gender: v.gender,
       languageCodes: v.languageCodes ?? [],
+      provider: v.provider,
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -12,6 +12,8 @@ export interface TTSVoice {
   id: string;
   name: string;
   previewUrl?: string;
+  gender?: 'Male' | 'Female' | 'Unknown';
+  languageCodes: { bcp47: string; iso639_3: string; display: string }[];
 }
 
 function createClient(config: TTSConfig) {
@@ -35,6 +37,11 @@ export async function fetchVoices(config: TTSConfig): Promise<TTSVoice[]> {
   const client = createClient(config);
   const voices = await client.getVoices();
   return voices
-    .map((v) => ({ id: v.id, name: v.name }))
+    .map((v) => ({
+      id: v.id,
+      name: v.name,
+      gender: v.gender,
+      languageCodes: v.languageCodes ?? [],
+    }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "diff": "^8.0.4",
         "framer-motion": "^12.38.0",
         "idb-keyval": "^6.2.2",
-        "js-tts-wrapper": "^0.1.76",
+        "js-tts-wrapper": "^0.1.77",
         "lucide-react": "^1.8.0",
         "mammoth": "^1.12.0",
         "next": "16.2.2",
@@ -5572,9 +5572,9 @@
       "license": "MIT"
     },
     "node_modules/js-tts-wrapper": {
-      "version": "0.1.76",
-      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.76.tgz",
-      "integrity": "sha512-OdcDdUZHzUuWOjQDQC5j9KxypygEBo1nFE8p9OQuQ06iQMQhwXd24t22UHY7GyIopkQ0bi2jC3vts/TmXyAdrQ==",
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.77.tgz",
+      "integrity": "sha512-5yFPb0wHFtw9nQDKyQkAnbsVizFCu93TFnEMxlDVEwicEaxEZBybRusi9Rb6i+7CJRt9b+a0xA7XxcjHxwUpeA==",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "diff": "^8.0.4",
         "framer-motion": "^12.38.0",
         "idb-keyval": "^6.2.2",
-        "js-tts-wrapper": "^0.1.77",
+        "js-tts-wrapper": "^0.1.78",
         "lucide-react": "^1.8.0",
         "mammoth": "^1.12.0",
         "next": "16.2.2",
@@ -5572,9 +5572,9 @@
       "license": "MIT"
     },
     "node_modules/js-tts-wrapper": {
-      "version": "0.1.77",
-      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.77.tgz",
-      "integrity": "sha512-5yFPb0wHFtw9nQDKyQkAnbsVizFCu93TFnEMxlDVEwicEaxEZBybRusi9Rb6i+7CJRt9b+a0xA7XxcjHxwUpeA==",
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.78.tgz",
+      "integrity": "sha512-YbunKbQ71OWvIu7Sf4kdzAI7NtPAACDQD1tVUArQhRVsN1xQ5Xv7gjRKVMV6aRHi3pea2ZkmhIs7v5Gpffk5AQ==",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "diff": "^8.0.4",
         "framer-motion": "^12.38.0",
         "idb-keyval": "^6.2.2",
-        "js-tts-wrapper": "^0.1.75",
+        "js-tts-wrapper": "^0.1.76",
         "lucide-react": "^1.8.0",
         "mammoth": "^1.12.0",
         "next": "16.2.2",
@@ -5572,9 +5572,9 @@
       "license": "MIT"
     },
     "node_modules/js-tts-wrapper": {
-      "version": "0.1.75",
-      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.75.tgz",
-      "integrity": "sha512-lDCyo6nyW5+cHhVIQf6c6hmTugYu6/d3sOtqBZmnWdtZMSsRaQG4HkqfRHGnEEHovac49p/yW1ggd+MweDZccQ==",
+      "version": "0.1.76",
+      "resolved": "https://registry.npmjs.org/js-tts-wrapper/-/js-tts-wrapper-0.1.76.tgz",
+      "integrity": "sha512-OdcDdUZHzUuWOjQDQC5j9KxypygEBo1nFE8p9OQuQ06iQMQhwXd24t22UHY7GyIopkQ0bi2jC3vts/TmXyAdrQ==",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.32.0",
@@ -7250,9 +7250,9 @@
       }
     },
     "node_modules/sherpa-onnx-darwin-arm64": {
-      "version": "1.12.36",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.12.36.tgz",
-      "integrity": "sha512-c1C7f2zO2BXNusrDlid5Mq5USfqq4oJrimnnHqNYtm4Kk2UzrxA9l6lAu2FZDj4gTQYRY4IJnlo0T7UXeOsjtQ==",
+      "version": "1.12.37",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.12.37.tgz",
+      "integrity": "sha512-zpqbH+2TI6dvg7mxGm30Mnv17aJL3ZfRGshMiBK85dHBfhzqMbKUHNXCzsHhiKBQTzti6JqG1YoRbYrJwvdUjA==",
       "cpu": [
         "arm64"
       ],
@@ -7263,9 +7263,9 @@
       ]
     },
     "node_modules/sherpa-onnx-darwin-x64": {
-      "version": "1.12.36",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.12.36.tgz",
-      "integrity": "sha512-pRaELEwQ60cfBTtERiw6muN+0+FhVom0As0erRcRqdPKLNK4HCCSUaoHPYLFT6W1VUiJBzABH+WE2+LTDyx5JA==",
+      "version": "1.12.37",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.12.37.tgz",
+      "integrity": "sha512-2mB1BhEJJLG8Ow/YGAe7c3AL5fSkk9qDk3wmZRsfDW+Gno5eBaUusXseDI0ltjh2mZcW74l9F19ez4CyhwqNQQ==",
       "cpu": [
         "x64"
       ],
@@ -7276,9 +7276,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-arm64": {
-      "version": "1.12.36",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.12.36.tgz",
-      "integrity": "sha512-Lv+j1Bq0Blp44O/i4gT4RieSDpiCoEPXfvNv0ABR2Gp6IbziI7gEsHgAf8HGjrA7EirtHAgX0o4hzUPW9yc+uw==",
+      "version": "1.12.37",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.12.37.tgz",
+      "integrity": "sha512-6yVnp7ucK4oJEjUfKbkyvJm+e6UdETTp7PnWFb1+Wr6nxSCN038BGSACCIKlVHEsQl+6huwrvymljkWrIro1mA==",
       "cpu": [
         "arm64"
       ],
@@ -7289,9 +7289,9 @@
       ]
     },
     "node_modules/sherpa-onnx-linux-x64": {
-      "version": "1.12.36",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.12.36.tgz",
-      "integrity": "sha512-Wul2WAaUt0e2zZaaQR4N3GTDhcZdz44w3FiStr195TI9U4uNxVbFgZbw9YsEMj8K7gm7JhoH2bnCn8fUJv88EQ==",
+      "version": "1.12.37",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.12.37.tgz",
+      "integrity": "sha512-WF69clWjTlBu6NIBdL8OLEEN4NwOlYjjB/AjCMs29pB6gtSzKJEKIjmTATfaSSExTGPeXsOriCXcMdHaMH4WNg==",
       "cpu": [
         "x64"
       ],
@@ -7302,23 +7302,23 @@
       ]
     },
     "node_modules/sherpa-onnx-node": {
-      "version": "1.12.36",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-node/-/sherpa-onnx-node-1.12.36.tgz",
-      "integrity": "sha512-AjdOE0qa3jAmS/zh0BwNVXn9ZRz8PpgCgcLIyf7IYxDfTMWIgHaRFisDL4QzttuDe3apvBXjP1Y7FtZPSRFqqQ==",
+      "version": "1.12.37",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-node/-/sherpa-onnx-node-1.12.37.tgz",
+      "integrity": "sha512-SpblPUl/ODliBk4WzKLRa0VPyc30I3HU9U/qRUmhya7eTNLkJE8sQOmj2kvRL8k2cWrHES2pyvRwwq1jT/MPpw==",
       "license": "Apache-2.0",
       "optionalDependencies": {
-        "sherpa-onnx-darwin-arm64": "^1.12.36",
-        "sherpa-onnx-darwin-x64": "^1.12.36",
-        "sherpa-onnx-linux-arm64": "^1.12.36",
-        "sherpa-onnx-linux-x64": "^1.12.36",
-        "sherpa-onnx-win-ia32": "^1.12.36",
-        "sherpa-onnx-win-x64": "^1.12.36"
+        "sherpa-onnx-darwin-arm64": "^1.12.37",
+        "sherpa-onnx-darwin-x64": "^1.12.37",
+        "sherpa-onnx-linux-arm64": "^1.12.37",
+        "sherpa-onnx-linux-x64": "^1.12.37",
+        "sherpa-onnx-win-ia32": "^1.12.37",
+        "sherpa-onnx-win-x64": "^1.12.37"
       }
     },
     "node_modules/sherpa-onnx-win-ia32": {
-      "version": "1.12.36",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.12.36.tgz",
-      "integrity": "sha512-An3O5tEq4P5xKBSZMq10F/w6q79fgdbFZ4NKPoflSKSW37TSyNz9MhHLHwhse/BMPa35eW14J9dsGG3DZTC/xA==",
+      "version": "1.12.37",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.12.37.tgz",
+      "integrity": "sha512-8kR6wk43mICTI78kTslColnO5d8Am0EbtPtz5NZH1LxOp4sktlQw3Ujc+/qlqJlPr0F4Ptdy8iG1CC0ELOv5VA==",
       "cpu": [
         "ia32"
       ],
@@ -7329,9 +7329,9 @@
       ]
     },
     "node_modules/sherpa-onnx-win-x64": {
-      "version": "1.12.36",
-      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.12.36.tgz",
-      "integrity": "sha512-wZLQflcvy8ynsU6B8GvqWIhOCAjP6+rnzyadF+qGWgZzMSCduapD63q++0QDRabGRBL8qfsd2n7O2dF/W2kccQ==",
+      "version": "1.12.37",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.12.37.tgz",
+      "integrity": "sha512-1h1UrJxzA1vkOO2G8JqRQkF9SfEhM/LYW+yFki5izCY5N+eaaxYKdZLmVZI3KAhxk28pkE6dnMETYi0nj2/Cuw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "diff": "^8.0.4",
     "framer-motion": "^12.38.0",
     "idb-keyval": "^6.2.2",
-    "js-tts-wrapper": "^0.1.75",
+    "js-tts-wrapper": "^0.1.76",
     "lucide-react": "^1.8.0",
     "mammoth": "^1.12.0",
     "next": "16.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "diff": "^8.0.4",
     "framer-motion": "^12.38.0",
     "idb-keyval": "^6.2.2",
-    "js-tts-wrapper": "^0.1.76",
+    "js-tts-wrapper": "^0.1.77",
     "lucide-react": "^1.8.0",
     "mammoth": "^1.12.0",
     "next": "16.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "diff": "^8.0.4",
     "framer-motion": "^12.38.0",
     "idb-keyval": "^6.2.2",
-    "js-tts-wrapper": "^0.1.77",
+    "js-tts-wrapper": "^0.1.78",
     "lucide-react": "^1.8.0",
     "mammoth": "^1.12.0",
     "next": "16.2.2",


### PR DESCRIPTION
Closes #116

## Summary

- Extended `TTSVoice` with `gender` and `languageCodes` fields (passed through from js-tts-wrapper's `UnifiedVoice`)
- Updated `fetchVoices()` to include these fields in the mapped result
- Added two filter dropdowns to `VoicePicker`: gender (All/Female/Male/Unknown) and language (dynamically derived from the loaded voice set)
- Filters compose with AND logic — Female + English (UK) shows only matching voices
- Count badge shows e.g. "11 of 642 voices"; empty-state message shown when no voices match
- No Convex schema changes — filtering is client-side state only

## Test plan
- [ ] Build passes: `npm run build`
- [ ] Settings page with Azure credentials: 600+ voices load, gender filter narrows list, language filter narrows further
- [ ] Combining Female + English (United Kingdom) shows ~11 voices
- [ ] Resetting to All genders + All languages restores full list
- [ ] ElevenLabs provider: language options derived from its voice set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice picker now supports filtering by gender and language with dedicated controls.
  * Shows a live count of voices matching the selected filters.
  * When no voices match filters, a clear "No voices match…" message is shown.
  * Preview button remains available for voices that include a preview.

* **Chores**
  * Updated underlying TTS integration/metadata for improved language and provider details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->