### PR TITLE
fix: auto-select first filtered voice when current selection is filtered out

### DIFF
--- a/components/settings/VoicePicker.tsx
+++ b/components/settings/VoicePicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { VoiceUtils, type UnifiedVoice } from 'js-tts-wrapper/browser';
 import { TTSVoice } from '@/lib/tts';
 
@@ -56,6 +56,14 @@ export function VoicePicker({
     if (langFilter !== 'All') result = VoiceUtils.filterByLanguage(result, langFilter);
     return result as unknown as TTSVoice[];
   }, [u, genderFilter, langFilter]);
+
+  // When filters change and the selected voice is no longer in the list, auto-select the first match
+  useEffect(() => {
+    if (filteredVoices.length === 0) return;
+    if (!filteredVoices.some((v) => v.id === selectedVoiceId)) {
+      onSelectVoice(filteredVoices[0].id);
+    }
+  }, [filteredVoices, selectedVoiceId, onSelectVoice]);
 
   return (
     <section>


### PR DESCRIPTION
## Summary
- When gender or language filters change and the currently selected voice is no longer in the filtered list, the dropdown visually snapped to the first option but `onSelectVoice` was never called — leaving the parent holding a stale voice ID
- Added a `useEffect` that fires whenever `filteredVoices` changes: if the selected voice ID is absent from the new list, it calls `onSelectVoice(filteredVoices[0].id)` to keep state in sync

## Test plan
- [ ] Load settings with Azure (600+ voices)
- [ ] Change gender filter to "Female" — active voice updates to first female voice
- [ ] Change language filter to a specific language — active voice updates again
- [ ] Reset filters to "All" — voice updates to first in full list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice picker now automatically updates the selected voice when filters are applied and the current selection is no longer available, defaulting to the first available option in the filtered list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->