### PR TITLE
feat: add Test button to VoicePicker (#119)

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -9,7 +9,7 @@ import { VoicePicker } from '@/components/settings/VoicePicker';
 import { OfflineGate } from '@/components/offline/OfflineGate';
 import { api } from '@/convex/_generated/api';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
-import { DEFAULT_AZURE_VOICE, DEFAULT_VOICE_ID, fetchVoices, TTSConfig, TTSVoice } from '@/lib/tts';
+import { DEFAULT_AZURE_VOICE, DEFAULT_VOICE_ID, fetchTTSBlob, fetchVoices, TTSConfig, TTSVoice } from '@/lib/tts';
 
 const MASKED = '****************';
 
@@ -115,6 +115,21 @@ function OnlineSettingsPage() {
     const audio = new Audio(voice.previewUrl);
     setPreviewAudio(audio);
     audio.onended = () => setPreviewAudio(null);
+    void audio.play();
+  }
+
+  async function handleTest() {
+    if (!ttsConfig) return;
+    const config = { ...ttsConfig, voiceId: selectedVoiceId };
+    const blob = await fetchTTSBlob('Hello, this is a test of the selected voice.', config);
+    previewAudio?.pause();
+    const url = URL.createObjectURL(blob);
+    const audio = new Audio(url);
+    setPreviewAudio(audio);
+    audio.onended = () => {
+      URL.revokeObjectURL(url);
+      setPreviewAudio(null);
+    };
     void audio.play();
   }
 
@@ -251,6 +266,7 @@ function OnlineSettingsPage() {
             voicesLoading={voicesLoading}
             onPreview={handlePreview}
             onSelectVoice={handleSelectVoice}
+            onTest={handleTest}
           />
         ) : null}
       </main>

--- a/components/settings/VoicePicker.tsx
+++ b/components/settings/VoicePicker.tsx
@@ -20,6 +20,7 @@ interface VoicePickerProps {
   voicesLoading: boolean;
   onPreview: (voice: TTSVoice) => void;
   onSelectVoice: (voiceId: string) => void;
+  onTest?: () => Promise<void>;
 }
 
 export function VoicePicker({
@@ -30,9 +31,11 @@ export function VoicePicker({
   voicesLoading,
   onPreview,
   onSelectVoice,
+  onTest,
 }: VoicePickerProps) {
   const [genderFilter, setGenderFilter] = useState<GenderFilter>('All');
   const [langFilter, setLangFilter] = useState<string>('All');
+  const [testing, setTesting] = useState(false);
 
   const u = voices as unknown as AsUnified;
 
@@ -125,6 +128,23 @@ export function VoicePicker({
                   className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)]"
                 >
                   Preview
+                </button>
+              ) : null}
+              {onTest ? (
+                <button
+                  type="button"
+                  disabled={testing}
+                  onClick={async () => {
+                    setTesting(true);
+                    try {
+                      await onTest();
+                    } finally {
+                      setTesting(false);
+                    }
+                  }}
+                  className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--muted)] transition-colors hover:text-[var(--foreground)] disabled:opacity-50"
+                >
+                  {testing ? 'Testing…' : 'Test'}
                 </button>
               ) : null}
             </div>


### PR DESCRIPTION
Closes #119

## Summary
- `VoicePicker` gets an optional `onTest: () => Promise<void>` prop — when provided a **Test** button appears next to the voice select
- Button shows **Testing…** and disables itself while synthesis is in flight; re-enables when done
- `settings/page.tsx` implements `handleTest`: builds a TTS config with the currently selected voice ID, calls `fetchTTSBlob('Hello, this is a test of the selected voice.')`, and plays the resulting audio blob via an object URL (revoked on end)
- Works for both Azure (no `previewUrl`) and ElevenLabs

## Test plan
- [ ] Select an Azure voice → click Test → hear the phrase spoken in that voice
- [ ] Select an ElevenLabs voice → click Test → hear the phrase
- [ ] Button shows "Testing…" while audio is being fetched
- [ ] Clicking Test while another preview is playing stops the previous audio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice preview capability. Users can now test their selected text-to-speech voice with a dedicated test button that generates and plays a sample audio clip. The button provides visual feedback during synthesis and playback, clearly indicating when the test is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->