### PR TITLE
feat: only re-download changed segments when a talk is edited

### DIFF
--- a/lib/audioStore.ts
+++ b/lib/audioStore.ts
@@ -14,6 +14,29 @@ export async function clearTalkAudio(talkId: string): Promise<void> {
   await Promise.all(talkKeys.map((key) => del(key)));
 }
 
+export async function clearStaleSegmentAudio(
+  talkId: string,
+  newSegments: Array<{ text: string; elements?: unknown[] }>
+): Promise<void> {
+  const allKeys = await keys<string>();
+  const marker = `:${talkId}:`;
+  const talkKeys = allKeys.filter((key) => key.includes(marker));
+
+  const validSuffixes = new Set(
+    newSegments.map((s) =>
+      s.elements ? `ssml:${JSON.stringify(s.elements)}` : s.text
+    )
+  );
+
+  const staleKeys = talkKeys.filter((key) => {
+    const idx = key.indexOf(marker);
+    const suffix = key.slice(idx + marker.length);
+    return !validSuffixes.has(suffix);
+  });
+
+  await Promise.all(staleKeys.map((key) => del(key)));
+}
+
 const talkStore = createStore('podium-talks', 'talks');
 
 export interface CachedTalk {

--- a/lib/offlineTalkMaintenance.ts
+++ b/lib/offlineTalkMaintenance.ts
@@ -1,4 +1,4 @@
-import { clearTalkAudio, saveTalkData } from '@/lib/audioStore';
+import { clearStaleSegmentAudio, saveTalkData } from '@/lib/audioStore';
 import { saveTalkPreparedState } from '@/lib/offlineStore';
 
 interface ReplaceCachedTalkDocumentArgs {
@@ -56,6 +56,6 @@ export async function invalidateTalkOfflineState({
   voiceKey,
 }: InvalidateTalkOfflineStateArgs): Promise<void> {
   await replaceCachedTalkDocument({ talkId, title, segments, voiceKey });
-  await clearTalkAudio(talkId);
+  await clearStaleSegmentAudio(talkId, segments);
   await markTalkDocumentOnly({ userId, talkId, segmentCount: segments.length });
 }


### PR DESCRIPTION
## Summary

- Replaces `clearTalkAudio` (wipes all cached audio) with `clearStaleSegmentAudio` (deletes only keys that don't match any segment in the updated talk)
- Cache keys are already content-addressable per segment, so unchanged segments remain in IndexedDB and load instantly on the next talk visit
- No callers needed to change — they already pass the new segments to `invalidateTalkOfflineState`

Closes #121

## Test plan

- [ ] Edit one segment in a multi-segment talk, navigate away, and re-open the talk — only the changed segment should trigger a TTS download (visible via Network tab)
- [ ] Edit a segment's SSML in the Segments editor, re-open the talk — same as above
- [ ] Restore a version from History — only segments that differ from the current version are re-downloaded
- [ ] Change voice in Settings, open the talk — all segments still re-download (voice change clears all audio via the existing voice-key check in `OnlineTalkPage`)
- [ ] Build passes: `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline talk maintenance to intelligently identify and selectively remove only outdated audio segments when talk content is updated, rather than clearing the entire audio cache. This refinement preserves all valid cached audio data while providing better overall performance during content synchronization and offline updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->