### PR TITLE
fix: forward arrow navigates freely between segments

### DIFF
--- a/app/talk/[id]/OfflineTalkPage.tsx
+++ b/app/talk/[id]/OfflineTalkPage.tsx
@@ -217,13 +217,13 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
             )}
             <button
               onClick={() => {
-                if (speakState !== 'spoken' || isLast) return;
+                if (isLocked || isLast) return;
                 audioRef.current?.pause();
                 audioRef.current = null;
                 setSpeakState('idle');
                 setIndex((prev) => prev + 1);
               }}
-              disabled={isLast || speakState !== 'spoken'}
+              disabled={isLocked || isLast}
               className="w-14 h-14 rounded-full bg-[var(--surface)] border border-[var(--border)] flex items-center justify-center text-[var(--foreground)] disabled:opacity-20 text-lg active:scale-95 transition-transform"
             >{'->'}</button>
           </div>

--- a/app/talk/[id]/OnlineTalkPage.tsx
+++ b/app/talk/[id]/OnlineTalkPage.tsx
@@ -509,8 +509,8 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
         </motion.button>
 
         <button
-          onClick={() => { if (speakState === 'spoken' && !isLast) doAdvance(); }}
-          disabled={isLocked || isLast || speakState !== 'spoken'}
+          onClick={() => { if (!isLast) doAdvance(); }}
+          disabled={isLocked || isLast}
           className="w-14 h-14 shrink-0 rounded-full bg-[var(--surface)] border border-[var(--border)] flex items-center justify-center text-[var(--foreground)] disabled:opacity-20 active:scale-95 transition-transform"
         >
           <ArrowRight className="w-5 h-5" />


### PR DESCRIPTION
## Summary

- Forward arrow (→) was blocked by `speakState !== 'spoken'` — unusable unless a segment had just finished playing
- Now mirrors the back arrow: disabled only while locked (mid-playback/loading) or at the last segment
- Fixes both `OnlineTalkPage` and `OfflineTalkPage`

Closes #123

## Test plan

- [ ] On talk page: tap forward arrow without speaking — should advance to next segment
- [ ] On talk page: tap forward arrow mid-speech — should be disabled (not interactable while speaking)
- [ ] On talk page: tap back arrow — still works as before
- [ ] On offline talk page: same checks as above
- [ ] Forward arrow disabled on last segment
- [ ] Back arrow disabled on first segment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved navigation controls for talk segments across the application. The advance button on offline and online pages now determines when progression is available based on segment position and lock status, rather than speaking state, resulting in more consistent navigation.
* Users experience more predictable behavior when moving through talk segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->