### PR TITLE
feat: show next segment preview above speak button

### DIFF
--- a/app/talk/[id]/OfflineTalkPage.tsx
+++ b/app/talk/[id]/OfflineTalkPage.tsx
@@ -202,6 +202,16 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
             </p>
           </button>
 
+          {/* Next segment preview */}
+          <div className="flex items-baseline gap-2 px-6 py-2 min-h-[2rem]">
+            {!isLast && (
+              <>
+                <span className="text-xs text-[var(--muted)] shrink-0">Next</span>
+                <span className="text-sm text-[var(--muted)]/70 truncate">{segments[index + 1]?.text}</span>
+              </>
+            )}
+          </div>
+
           <div className={`flex items-center justify-between px-8 pb-10 transition-opacity duration-200 ${
             isLocked ? 'opacity-0 pointer-events-none' : 'opacity-100'
           }`}>

--- a/app/talk/[id]/OnlineTalkPage.tsx
+++ b/app/talk/[id]/OnlineTalkPage.tsx
@@ -462,6 +462,23 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
         </div>
       </div>
 
+      {/* Next segment preview */}
+      <AnimatePresence mode="wait">
+        {!isLast && (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="flex items-baseline gap-2 px-6 py-2"
+          >
+            <span className="text-xs text-[var(--muted)] shrink-0">Next</span>
+            <span className="text-sm text-[var(--muted)]/70 truncate">{segments[index + 1]?.text}</span>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* Nav row — back | speak/next | forward */}
       <div className="flex items-center gap-3 px-6 pt-4 pb-10">
         <button


### PR DESCRIPTION
## Summary

- Adds a subtle "Next [text...]" strip between the main content area and the nav row in both `OnlineTalkPage` and `OfflineTalkPage`
- Hidden on the last segment; no layout shift (offline page uses `min-h` placeholder)
- Online page fades the strip in/out via framer-motion as segments change
- No changes to navigation or speak behaviour

Closes #125

## Test plan

- [ ] Open a talk with 3+ segments — preview shows next segment text below the main content
- [ ] Advance through segments — preview updates each time
- [ ] Reach the last segment — preview strip disappears
- [ ] Verify long text truncates to one line without overflow
- [ ] Check offline talk page shows same behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a next segment preview that displays the upcoming message text, helping users anticipate what comes next before advancing to it. The preview is automatically hidden on the final segment and includes smooth animated transitions in the online experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->