### PR TITLE
Preserve talk position across connectivity drops

### DIFF
--- a/app/talk/[id]/OfflineTalkPage.tsx
+++ b/app/talk/[id]/OfflineTalkPage.tsx
@@ -5,6 +5,7 @@ import { OfflineBanner } from '@/components/offline/OfflineBanner';
 import { OfflineUnavailable } from '@/components/offline/OfflineUnavailable';
 import { useOfflineBoot } from '@/hooks/useOfflineBoot';
 import { getCachedAudio, getTalkData, type CachedTalk } from '@/lib/audioStore';
+import { readTalkIndex, writeTalkIndex } from '@/lib/presentationState';
 
 type SpeakState = 'idle' | 'loading' | 'speaking' | 'spoken';
 
@@ -13,10 +14,11 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
   const { library, lastSyncedAt } = useOfflineBoot();
   const [talk, setTalk] = useState<CachedTalk | null | undefined>(undefined);
   const [loadedAudioCount, setLoadedAudioCount] = useState(0);
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useState<number>(() => readTalkIndex(id) ?? 0);
   const [speakState, setSpeakState] = useState<SpeakState>('idle');
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const audioUrls = useRef<Map<number, string>>(new Map());
+  const hasHydratedIndexRef = useRef(false);
 
   const status = library?.talkStatusById[id];
 
@@ -74,6 +76,25 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
   }, [id, status?.hasAudio, talk]);
 
   const segments = talk?.segments ?? [];
+
+  // Persist current segment index so remounts (hard refresh, online/offline
+  // gate flips) can resume the user where they were rather than jumping to 0.
+  useEffect(() => {
+    if (!hasHydratedIndexRef.current) {
+      hasHydratedIndexRef.current = true;
+      return; // skip writing the initial value we just read
+    }
+    writeTalkIndex(id, index);
+  }, [id, index]);
+
+  // If the cached talk has fewer segments than the saved/current index, clamp
+  // to the last valid segment so rendering never crashes on `current.text`.
+  useEffect(() => {
+    if (segments.length > 0 && index >= segments.length) {
+      setIndex(Math.max(0, segments.length - 1));
+    }
+  }, [segments.length, index]);
+
   const audioReady = !!status?.hasAudio && !!talk?.voiceKey && loadedAudioCount === segments.length && segments.length > 0;
   const current = segments[index];
   const isLast = index === segments.length - 1;

--- a/app/talk/[id]/OnlineTalkPage.tsx
+++ b/app/talk/[id]/OnlineTalkPage.tsx
@@ -10,6 +10,7 @@ import { useOfflineBoot } from '@/hooks/useOfflineBoot';
 import { useOnlineCurrentUser } from '@/hooks/useOnlineCurrentUser';
 import { clearTalkAudio, getCachedAudio, getTalkData, saveTalkData, setCachedAudio } from '@/lib/audioStore';
 import { getTalkPreparedState, saveTalkPreparedState } from '@/lib/offlineStore';
+import { readTalkIndex, writeTalkIndex } from '@/lib/presentationState';
 import { buildSSML, SegmentElement } from '@/lib/ssml';
 import { fetchTTSBlob, TTSConfig } from '@/lib/tts';
 import OfflineTalkPage from './OfflineTalkPage';
@@ -26,10 +27,11 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
   const talk = useQuery(api.talks.get, { id: id as Id<'talks'> });
   const settings = useQuery(api.users.getSettings, clerkId ? { clerkId } : 'skip');
 
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useState<number>(() => readTalkIndex(id) ?? 0);
   const [speakState, setSpeakState] = useState<SpeakState>('idle');
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const audioUrls = useRef<Map<number, string>>(new Map());
+  const hasHydratedIndexRef = useRef(false);
   const [cacheLoaded, setCacheLoaded] = useState(0);
   const [cacheReady, setCacheReady] = useState(false);
   const [cacheFailed, setCacheFailed] = useState(false);
@@ -230,6 +232,25 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cacheLoaded, index, waitingForSegment]);
+
+  // Persist current segment index so remounts (hard refresh, offline gate
+  // flips) can resume the user where they were rather than jumping to 0.
+  useEffect(() => {
+    if (!hasHydratedIndexRef.current) {
+      hasHydratedIndexRef.current = true;
+      return; // skip writing the initial value we just read
+    }
+    writeTalkIndex(id, index);
+  }, [id, index]);
+
+  // If the talk was edited and now has fewer segments than the saved/current
+  // index, clamp to the last valid segment so rendering never crashes on
+  // `current.text`.
+  useEffect(() => {
+    if (segments.length > 0 && index >= segments.length) {
+      setIndex(Math.max(0, segments.length - 1));
+    }
+  }, [segments.length, index]);
 
   const current = segments[index];
   const isLast = index === segments.length - 1;

--- a/app/talk/[id]/page.tsx
+++ b/app/talk/[id]/page.tsx
@@ -8,6 +8,7 @@ export default function TalkPage({ params }: { params: Promise<{ id: string }> }
   return (
     <OfflineGate
       emergency={<OfflineTalkPage params={params} />}
+      alwaysMountChildren
       unavailableTitle="Offline talk unavailable"
       unavailableMessage="Connect once and open your library online before Podium can present talks offline."
     >

--- a/components/offline/OfflineGate.tsx
+++ b/components/offline/OfflineGate.tsx
@@ -10,6 +10,16 @@ interface OfflineGateProps {
   href?: string;
   actionLabel?: string;
   emergency?: React.ReactNode;
+  /**
+   * When true, always render `children` regardless of connectivity mode.
+   * The wrapped page is expected to handle offline states internally
+   * (banner, cached playback, internal fallback) instead of being swapped out.
+   *
+   * This preserves component state, refs, and in-flight resources across
+   * online/offline transitions — critical for flows like an active presentation
+   * where unmounting would lose the user's position.
+   */
+  alwaysMountChildren?: boolean;
 }
 
 export function OfflineGate({
@@ -19,8 +29,13 @@ export function OfflineGate({
   href,
   actionLabel,
   emergency,
+  alwaysMountChildren,
 }: OfflineGateProps) {
   const { mode } = useOfflineBoot();
+
+  if (alwaysMountChildren) {
+    return <>{children}</>;
+  }
 
   if (mode === 'offline-emergency') {
     return emergency ?? (

--- a/lib/presentationState.ts
+++ b/lib/presentationState.ts
@@ -1,0 +1,30 @@
+// sessionStorage-backed persistence for the current segment index of a talk.
+//
+// This is a safety net against component remounts (hard refresh, accidental
+// navigation, etc.) so the user's position survives. Scoped to the tab via
+// sessionStorage — opening the same talk in a new tab intentionally starts
+// at segment 0.
+
+const keyFor = (talkId: string) => `podium:talk:index:${talkId}`;
+
+export function readTalkIndex(talkId: string): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(keyFor(talkId));
+    if (!raw) return null;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < 0) return null;
+    return Math.floor(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function writeTalkIndex(talkId: string, index: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(keyFor(talkId), String(index));
+  } catch {
+    // Storage may throw in private mode or when full — best-effort persistence.
+  }
+}


### PR DESCRIPTION
Closes #132.

## Summary
- `OfflineGate` now supports `alwaysMountChildren`; `/talk/[id]` opts in so the talk subtree survives `online`/`offline` events instead of being swapped out and losing its segment index.
- New `lib/presentationState.ts` persists the current segment index per talk id in `sessionStorage` so hard refreshes and any remaining remounts resume where the user was.
- Both `OnlineTalkPage` and `OfflineTalkPage` read the saved index via a lazy `useState` initializer, write it back with a hydration-guarded effect, and clamp against `segments.length` so edits that shrink a talk can't crash rendering.

## Test plan
- [ ] Start a talk with 10+ segments, advance to segment 5, toggle DevTools Network → Offline, wait ~3s. UI stays on segment 5.
- [ ] Re-enable the network. UI remains on segment 5 and the TTS preparation spinner does not reappear.
- [ ] Hard-refresh (F5) mid-talk on segment 5. Resumes at segment 5.
- [ ] Open the same talk in a new tab. Starts at segment 0 (sessionStorage is per-tab — expected).
- [ ] Edit the talk to have fewer segments than the saved index, reopen. Clamp effect lands on the last segment (no crash).
- [ ] `npm run build` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Talks now preserve your current segment position across sessions, allowing you to seamlessly resume presentations from where you left off.

* **Bug Fixes**
  * Fixed crashes and rendering issues when viewing talks that have been edited to contain fewer segments than previously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->