### PR TITLE
feat: add back-to-start button on talk presentation page

### DIFF
--- a/app/talk/[id]/OfflineTalkPage.tsx
+++ b/app/talk/[id]/OfflineTalkPage.tsx
@@ -16,6 +16,7 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
   const [loadedAudioCount, setLoadedAudioCount] = useState(0);
   const [index, setIndex] = useState<number>(() => readTalkIndex(id) ?? 0);
   const [speakState, setSpeakState] = useState<SpeakState>('idle');
+  const [showRestartConfirm, setShowRestartConfirm] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const audioUrls = useRef<Map<number, string>>(new Map());
   const hasHydratedIndexRef = useRef(false);
@@ -143,6 +144,15 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
     setIndex((prev) => prev - 1);
   }
 
+  function goToStart() {
+    if (isLocked || index === 0) return;
+    audioRef.current?.pause();
+    audioRef.current = null;
+    setSpeakState('idle');
+    setIndex(0);
+    setShowRestartConfirm(false);
+  }
+
   if (talk === undefined) {
     return (
       <div className="flex min-h-dvh items-center justify-center bg-[var(--background)]">
@@ -236,11 +246,19 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
           <div className={`flex items-center justify-between px-8 pb-10 transition-opacity duration-200 ${
             isLocked ? 'opacity-0 pointer-events-none' : 'opacity-100'
           }`}>
-            <button
-              onClick={back}
-              disabled={index === 0}
-              className="w-14 h-14 rounded-full bg-[var(--surface)] border border-[var(--border)] flex items-center justify-center text-[var(--foreground)] disabled:opacity-20 text-lg active:scale-95 transition-transform"
-            >{'<-'}</button>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => setShowRestartConfirm(true)}
+                disabled={isLocked || index === 0}
+                aria-label="Back to start"
+                className="w-14 h-14 rounded-full bg-[var(--surface)] border border-[var(--border)] flex items-center justify-center text-[var(--foreground)] disabled:opacity-20 text-lg active:scale-95 transition-transform"
+              >{'|<'}</button>
+              <button
+                onClick={back}
+                disabled={index === 0}
+                className="w-14 h-14 rounded-full bg-[var(--surface)] border border-[var(--border)] flex items-center justify-center text-[var(--foreground)] disabled:opacity-20 text-lg active:scale-95 transition-transform"
+              >{'<-'}</button>
+            </div>
             {speakState === 'spoken' && isLast ? (
               <a href="/library" className="text-sm text-[var(--primary)] font-medium">Done</a>
             ) : (
@@ -257,6 +275,33 @@ export default function OfflineTalkPage({ params }: { params: Promise<{ id: stri
               disabled={isLocked || isLast}
               className="w-14 h-14 rounded-full bg-[var(--surface)] border border-[var(--border)] flex items-center justify-center text-[var(--foreground)] disabled:opacity-20 text-lg active:scale-95 transition-transform"
             >{'->'}</button>
+          </div>
+        </>
+      )}
+
+      {showRestartConfirm && (
+        <>
+          <div
+            className="fixed inset-0 z-30 bg-black/60"
+            onClick={() => setShowRestartConfirm(false)}
+          />
+          <div className="fixed left-1/2 top-1/2 z-40 w-[90%] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-[var(--border)] bg-[var(--background)] p-6 shadow-lg">
+            <h3 className="text-lg font-semibold text-[var(--foreground)]">Restart talk from the beginning?</h3>
+            <p className="mt-2 text-sm text-[var(--muted)]">This will jump back to the first segment.</p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setShowRestartConfirm(false)}
+                className="rounded-full border border-[var(--border)] bg-[var(--surface)] px-4 py-2 text-sm text-[var(--foreground)]"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={goToStart}
+                className="rounded-full bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-white"
+              >
+                Restart
+              </button>
+            </div>
           </div>
         </>
       )}

--- a/app/talk/[id]/OnlineTalkPage.tsx
+++ b/app/talk/[id]/OnlineTalkPage.tsx
@@ -3,7 +3,7 @@
 import { use, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'convex/react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Download, WifiOff, Volume2, ChevronRight, ArrowLeft, ArrowRight } from 'lucide-react';
+import { Download, WifiOff, Volume2, ChevronRight, ChevronsLeft, ArrowLeft, ArrowRight } from 'lucide-react';
 import { api } from '@/convex/_generated/api';
 import { Id } from '@/convex/_generated/dataModel';
 import { useOfflineBoot } from '@/hooks/useOfflineBoot';
@@ -29,6 +29,7 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
 
   const [index, setIndex] = useState<number>(() => readTalkIndex(id) ?? 0);
   const [speakState, setSpeakState] = useState<SpeakState>('idle');
+  const [showRestartConfirm, setShowRestartConfirm] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const audioUrls = useRef<Map<number, string>>(new Map());
   const hasHydratedIndexRef = useRef(false);
@@ -306,6 +307,15 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
     setIndex((prev) => prev - 1);
   }
 
+  function goToStart() {
+    if (isLocked || index === 0) return;
+    audioRef.current?.pause();
+    audioRef.current = null;
+    setSpeakState('idle');
+    setIndex(0);
+    setShowRestartConfirm(false);
+  }
+
   if (forceOfflineFallback && library) {
     return <OfflineTalkPage params={params} />;
   }
@@ -500,8 +510,17 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
         )}
       </AnimatePresence>
 
-      {/* Nav row — back | speak/next | forward */}
+      {/* Nav row — restart | back | speak/next | forward */}
       <div className="flex items-center gap-3 px-6 pt-4 pb-10">
+        <button
+          onClick={() => setShowRestartConfirm(true)}
+          disabled={isLocked || index === 0}
+          aria-label="Back to start"
+          className="w-14 h-14 shrink-0 rounded-full bg-[var(--surface)] border border-[var(--border)] flex items-center justify-center text-[var(--foreground)] disabled:opacity-20 active:scale-95 transition-transform"
+        >
+          <ChevronsLeft className="w-5 h-5" />
+        </button>
+
         <button
           onClick={back}
           disabled={isLocked || index === 0}
@@ -559,6 +578,33 @@ export default function OnlineTalkPage({ params }: { params: Promise<{ id: strin
         <div className="flex justify-center pb-6 -mt-4">
           <a href="/library" className="text-sm text-[var(--primary)] font-medium">Back to library</a>
         </div>
+      )}
+
+      {showRestartConfirm && (
+        <>
+          <div
+            className="fixed inset-0 z-30 bg-black/60"
+            onClick={() => setShowRestartConfirm(false)}
+          />
+          <div className="fixed left-1/2 top-1/2 z-40 w-[90%] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-[var(--border)] bg-[var(--background)] p-6 shadow-lg">
+            <h3 className="text-lg font-semibold text-[var(--foreground)]">Restart talk from the beginning?</h3>
+            <p className="mt-2 text-sm text-[var(--muted)]">This will jump back to the first segment.</p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={() => setShowRestartConfirm(false)}
+                className="rounded-full border border-[var(--border)] bg-[var(--surface)] px-4 py-2 text-sm text-[var(--foreground)]"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={goToStart}
+                className="rounded-full bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-white"
+              >
+                Restart
+              </button>
+            </div>
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
Closes #134

## Summary
- Adds a dedicated "back to start" button to the left of the existing back arrow on both the online (`OnlineTalkPage.tsx`) and offline (`OfflineTalkPage.tsx`) talk presentation pages.
- Tapping the button opens a centered confirmation modal ("Restart talk from the beginning?") so a stray tap mid-speech doesn't wipe the user's position.
- Disable conditions match the existing back button: disabled when audio is loading/playing (`isLocked`) or already on the first segment (`index === 0`).

## Implementation notes
- **Online page** uses the `ChevronsLeft` icon from `lucide-react` (same icon pack already in use). Nav row order: **restart → back → speak/next → forward**.
- **Offline page** uses the text label `|<` to match its existing `<-` / `->` text-button style. Restart + back are wrapped in a flex group so `justify-between` keeps forward anchored right.
- Modal styling follows the existing `AssignTalkSheet` backdrop pattern (`components/library/AssignTalkSheet.tsx`) — `fixed inset-0 z-30 bg-black/60` backdrop, click-to-close.
- No new dependencies, shared components, Convex schema changes, or hook changes.
- Icon-only button has `aria-label="Back to start"`.

## Test plan
- [ ] `npm run build` passes locally (verified)
- [ ] Online page: open a talk with 3+ segments, advance to segment 3, confirm new button appears and is enabled
- [ ] Online page: tap it → modal appears → Cancel / backdrop click closes modal, position preserved
- [ ] Online page: tap it → Restart → modal closes, segment index resets to 0, audio stops, speak state resets to idle
- [ ] Online page: on segment 0, button is visibly disabled (20% opacity)
- [ ] Online page: during audio playback, button is disabled
- [ ] Offline page: repeat above flow with network disabled (nav row already hides while locked, so only `index === 0` disable state is user-visible)
- [ ] Keyboard focus tab-order: restart → back → speak → forward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added restart functionality to talks with confirmation modal to prevent accidental resets
  * New restart button in navigation controls to return to the beginning of a talk
  * Restart action pauses audio and resets the playback state to the first segment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->